### PR TITLE
chore(release): push to two quay.io registries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,8 +116,14 @@ jobs:
       - name: Registry login (quay.io/enterprise-contract)
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
 
+      - name: Registry login (quay.io/conforma)
+        run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }} -p ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }} quay.io
+
       - name: Create and push image (quay.io/conforma/cli)
         run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
+
+      - name: Create and push image (quay.io/enterprise-contract/ec-cli)
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=quay.io/enterprise-contract/ec-cli ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
       # verify ec works in the image and show the version
       - name: verify the ec image


### PR DESCRIPTION
This commit ensures that the cli image is pushed to both the `quay.io/enterprise-contract/ec-cli` registry and the `quay.io/conforma/cli` registry as part of the transition from the `enterprise-contract` name to the new `conforma` name.

Ref: EC-1110