### PR TITLE
chore: update release.yaml to use two quay repos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,27 +113,46 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
-      - name: Registry login (quay.io/enterprise-contract)
-        run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
-
       - name: Registry login (quay.io/conforma)
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }} -p ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }} quay.io
 
       - name: Create and push image (quay.io/conforma/cli)
+        env:
+          IMAGE_REPO: quay.io/conforma/cli
         run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
+      - name: Registry login (quay.io/enterprise-contract)
+        run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
+
       - name: Create and push image (quay.io/enterprise-contract/ec-cli)
-        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=quay.io/enterprise-contract/ec-cli ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
+        env:
+          IMAGE_REPO: quay.io/enterprise-contract/ec-cli
+        run: make dist-image-push IMAGE_TAG=$TAG IMAGE_REPO=$IMAGE_REPO ADD_IMAGE_TAG="snapshot $TAG_TIMESTAMP"
 
       # verify ec works in the image and show the version
-      - name: verify the ec image
+      - name: verify the ec image (quay.io/conforma/cli)
         env:
           IMAGE_TAG: snapshot
+          IMAGE_REPO: quay.io/conforma/cli
         run: make verify-image
+
+      - name: verify the ec image (quay.io/enterprise-contract/ec-cli)
+        env:
+          IMAGE_TAG: snapshot
+          IMAGE_REPO: quay.io/enterprise-contract/ec-cli
+        run: make verify-image
+
+      - name: Create and push the tekton bundle (quay.io/conforma/ec-task-bundle)
+        env:
+          TASK_REPO: quay.io/conforma/ec-task-bundle
+          IMAGE_REPO: quay.io/conforma/cli
+          TASKS: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
+        run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP" TASKS=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASKS | yq 'select(. != null)')
 
       - name: Create and push the tekton bundle (quay.io/enterprise-contract/ec-task-bundle)
         env:
           TASK_REPO: quay.io/enterprise-contract/ec-task-bundle
+          IMAGE_REPO: quay.io/enterprise-contract/ec-cli
           TASKS: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
         run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP" TASKS=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASKS | yq 'select(. != null)')
 


### PR DESCRIPTION
This commit updates the release process so that it pushes to `quay.io/enterprise-contract/ec-cli` as well as `quay.io/conforma/cli`.

Ref: EC-1110