### PR TITLE
chore(release): add additional registry logins

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,12 +142,18 @@ jobs:
           IMAGE_REPO: quay.io/enterprise-contract/ec-cli
         run: make verify-image
 
+      - name: Registry login (quay.io/conforma)
+        run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }} -p ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }} quay.io
+
       - name: Create and push the tekton bundle (quay.io/conforma/ec-task-bundle)
         env:
           TASK_REPO: quay.io/conforma/ec-task-bundle
           IMAGE_REPO: quay.io/conforma/cli
           TASKS: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
         run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP" TASKS=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASKS | yq 'select(. != null)')
+
+      - name: Registry login (quay.io/enterprise-contract)
+        run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io
 
       - name: Create and push the tekton bundle (quay.io/enterprise-contract/ec-task-bundle)
         env:


### PR DESCRIPTION
This commit adds additional registry login steps to the release workflow to address authentication issues for pushing the tekton task bundles.

Ref: EC-1110