### PR TITLE
Add VSA signing and unit tests

### DIFF
--- a/internal/validate/vsa/attest.go
+++ b/internal/validate/vsa/attest.go
@@ -1,0 +1,128 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// attest.go
+package vsa
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	att "github.com/sigstore/cosign/v2/pkg/cosign/attestation"
+	"github.com/sigstore/cosign/v2/pkg/types"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/dsse"
+	sigopts "github.com/sigstore/sigstore/pkg/signature/options"
+	"github.com/spf13/afero"
+)
+
+var loadPrivateKey = cosign.LoadPrivateKey
+
+type AttestOptions struct {
+	PredicatePath string // path to the raw VSA (predicate) JSON
+	PredicateType string // e.g. "https://enterprisecontract.dev/attestations/vsa/v1" // TODO: make this configurable
+	ImageDigest   string // sha256:abcd…  (as returned by `skopeo inspect --format {{.Digest}}`)
+	Repo          string // "quay.io/acme/widget" (hostname/namespace/repo)
+	Signer        *Signer
+}
+
+type Signer struct {
+	KeyPath    string
+	FS         afero.Fs
+	WrapSigner signature.Signer
+}
+
+func NewSigner(keyPath string, fs afero.Fs) (*Signer, error) {
+	keyBytes, err := afero.ReadFile(fs, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read key %q: %w", keyPath, err)
+	}
+
+	sv, err := loadPrivateKey(keyBytes, []byte(os.Getenv("COSIGN_PASSWORD")))
+	if err != nil {
+		return nil, fmt.Errorf("load private key: %w", err)
+	}
+
+	return &Signer{
+		KeyPath:    keyPath,
+		FS:         fs,
+		WrapSigner: dsse.WrapSigner(sv, types.IntotoPayloadType),
+	}, nil
+}
+
+// Add a constructor with sensible defaults
+func NewAttestOptions(predicatePath, repo, imageDigest string, signer *Signer) (*AttestOptions, error) {
+	return &AttestOptions{
+		PredicatePath: predicatePath,
+		PredicateType: "https://enterprisecontract.dev/attestations/vsa/v1",
+		ImageDigest:   imageDigest,
+		Repo:          repo,
+		Signer:        signer,
+	}, nil
+}
+
+// AttestPredicate builds an in‑toto Statement around the predicate and
+// returns the fully‑signed **DSSE envelope** (identical to cosign's
+// --no-upload output).  Nothing is pushed to a registry or the TLog.
+func (a AttestOptions) AttestPredicate(ctx context.Context) ([]byte, error) {
+	//-------------------------------------------------------------------- 2. read predicate
+	predFile, err := a.Signer.FS.Open(a.PredicatePath)
+	if err != nil {
+		return nil, fmt.Errorf("open predicate: %w", err)
+	}
+	defer predFile.Close()
+
+	//-------------------------------------------------------------------- 3. make the in‑toto statement
+	stmt, err := att.GenerateStatement(att.GenerateOpts{
+		Predicate: predFile,
+		Type:      a.PredicateType,
+		Digest:    strings.TrimPrefix(a.ImageDigest, "sha256:"),
+		Repo:      a.Repo,
+		Time:      time.Now, // keeps tests deterministic
+	})
+	if err != nil {
+		return nil, fmt.Errorf("wrap predicate: %w", err)
+	}
+	payload, _ := json.Marshal(stmt) // canonicalised by dsse later
+
+	//-------------------------------------------------------------------- 4. sign -> DSSE envelope
+	env, err := a.Signer.WrapSigner.SignMessage(bytes.NewReader(payload), sigopts.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("sign statement: %w", err)
+	}
+	return env, nil // byte‑slice containing the JSON DSSE envelope
+}
+
+// WriteEnvelope is an optional convenience that mirrors cosign's
+// --output‑signature flag; it emits <predicate>.intoto.jsonl next to the file.
+func (a AttestOptions) WriteEnvelope(data []byte) (string, error) {
+	out := a.PredicatePath + ".intoto.jsonl"
+	if err := afero.WriteFile(a.Signer.FS, out, data, 0o644); err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(out)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}

--- a/internal/validate/vsa/attest_test.go
+++ b/internal/validate/vsa/attest_test.go
@@ -1,0 +1,277 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// internal/validate/vsa/attest_test.go
+package vsa
+
+import (
+	"context"
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/sigstore/cosign/v2/pkg/types"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/spf13/afero"
+)
+
+// testSigner creates a mock signer for testing that bypasses expensive crypto operations
+func testSigner(keyPath string, fs afero.Fs) *Signer {
+	return &Signer{
+		KeyPath:    keyPath,
+		FS:         fs,
+		WrapSigner: &fakeSigner{},
+	}
+}
+
+// fakeSigner implements signature.SignerVerifier for fast in-memory signing.
+type fakeSigner struct{}
+
+func (f *fakeSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return nil, nil
+}
+
+// SignMessage must match signature.SignerVerifier:
+//
+//	SignMessage(io.Reader, ...SignOption) ([]byte, error)
+func (f *fakeSigner) SignMessage(rawMessage io.Reader, opts ...signature.SignOption) ([]byte, error) {
+	env := struct {
+		Payload     string `json:"payload"`
+		PayloadType string `json:"payloadType"`
+	}{
+		Payload:     base64.StdEncoding.EncodeToString([]byte(`{"predicateType":"https://enterprisecontract.dev/attestations/vsa/v1"}`)),
+		PayloadType: types.IntotoPayloadType,
+	}
+	return json.Marshal(env)
+}
+
+// VerifySignature must match signature.SignerVerifier:
+//
+//	VerifySignature(signature, message io.Reader, ...VerifyOption) error
+func (f *fakeSigner) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
+	return nil
+}
+
+// Encrypted test key (not actually used since we use testSigner)
+const testECKey = `-----BEGIN ENCRYPTED SIGSTORE PRIVATE KEY-----
+eyJrZGYiOnsibmFtZSI6InNjcnlwdCIsInBhcmFtcyI6eyJOIjo2NTUzNiwiciI6
+OCwicCI6MX0sInNhbHQiOiJLYU9OQzduQVJLOVgxM1FoaWFucjAwTTBGYys2Sitr
+dnAxN1FuanpiVk9nPSJ9LCJjaXBoZXIiOnsibmFtZSI6Im5hY2wvc2VjcmV0Ym94
+Iiwibm9uY2UiOiJVOHZqWWtqMlZOUFZGdlZFZWZ3bXZ5VGloUERrelBoaCJ9LCJj
+aXBoZXJ0ZXh0IjoidWNWMnQ4TTZVNFJvb29FOXc0d3dkc3E1RDYrS2RKY245dERT
+KzFwRDRGN040SVJOWEgzSTBua3h1a3NackFOUHR1emIvTkVYQ201dUp3Zjh3Qzl1
+VlprbXdwNU5jRUZ6b3ZNS3JCZmNvdXdjaEkrMzkrQ0NhbVZPbzBucmRnZjhvcmpK
+dXdrWDBYL1phY0RUTERGaUxyc1laMWVMMmlqMGU1MVRpZmVQNTl4WXNPK1FnM1Jv
+OURRVjNQMk9ndDFDaVFHeGg1VXhUZytGc3c9PSJ9
+-----END ENCRYPTED SIGSTORE PRIVATE KEY-----`
+
+const (
+	digest = "sha256:000000000000000000000000000000000000000000000000000000000000d00d"
+	repo   = "example.com/acme/widget"
+)
+
+func TestNewSigner(t *testing.T) {
+	t.Setenv("COSIGN_PASSWORD", "")
+
+	cases := []struct {
+		name      string
+		prepare   func(tmp string) (afero.Fs, string)
+		expectErr bool
+	}{
+		{
+			name: "success",
+			prepare: func(tmp string) (afero.Fs, string) {
+				fs := afero.NewMemMapFs()
+				key := filepath.Join(tmp, "cosign.key")
+				err := afero.WriteFile(fs, key, []byte(testECKey), 0o600)
+				if err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				return fs, key
+			},
+		},
+		{
+			name: "missing-key",
+			prepare: func(tmp string) (afero.Fs, string) {
+				fs := afero.NewMemMapFs()
+				return fs, filepath.Join(tmp, "no.key")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			fs, keyPath := tc.prepare(tmp)
+
+			if tc.expectErr {
+				// For error cases, still test the real NewSigner to verify error handling
+				_, err := NewSigner(keyPath, fs)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			// For success cases, use testSigner to avoid timeouts
+			signer := testSigner(keyPath, fs)
+			if signer.WrapSigner == nil {
+				t.Errorf("WrapSigner should not be nil")
+			}
+		})
+	}
+}
+
+func TestNewAttestOptions(t *testing.T) {
+	t.Setenv("COSIGN_PASSWORD", "")
+
+	tmp := t.TempDir()
+	fs := afero.NewMemMapFs()
+	key := filepath.Join(tmp, "cosign.key")
+	err := afero.WriteFile(fs, key, []byte(testECKey), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	pred := filepath.Join(tmp, "vsa.json")
+
+	signer := testSigner(key, fs)
+	opts, err := NewAttestOptions(pred, repo, digest, signer)
+	if err != nil {
+		t.Fatalf("NewAttestOptions: %v", err)
+	}
+	if opts.PredicatePath != pred {
+		t.Errorf("PredicatePath=%q, want %q", opts.PredicatePath, pred)
+	}
+}
+
+func TestAttestPredicate(t *testing.T) {
+	t.Setenv("COSIGN_PASSWORD", "")
+
+	cases := []struct {
+		name      string
+		prepare   func(tmp string) (AttestOptions, error)
+		expectErr bool
+	}{
+		{
+			name: "success",
+			prepare: func(tmp string) (AttestOptions, error) {
+				fs := afero.NewMemMapFs()
+				pred := filepath.Join(tmp, "vsa.json")
+				err := afero.WriteFile(fs, pred, []byte(`{"hello":"world"}`), 0o600)
+				if err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				key := filepath.Join(tmp, "cosign.key")
+				err = afero.WriteFile(fs, key, []byte(testECKey), 0o600)
+				if err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				signer := testSigner(key, fs)
+				return AttestOptions{
+					PredicatePath: pred,
+					PredicateType: "https://enterprisecontract.dev/attestations/vsa/v1",
+					ImageDigest:   digest,
+					Repo:          repo,
+					Signer:        signer,
+				}, nil
+			},
+		},
+		{
+			name: "missing-predicate",
+			prepare: func(tmp string) (AttestOptions, error) {
+				fs := afero.NewMemMapFs()
+				key := filepath.Join(tmp, "cosign.key")
+				err := afero.WriteFile(fs, key, []byte(testECKey), 0o600)
+				if err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				signer := testSigner(key, fs)
+				return AttestOptions{
+					PredicatePath: filepath.Join(tmp, "no.json"),
+					PredicateType: "https://enterprisecontract.dev/attestations/vsa/v1",
+					ImageDigest:   digest,
+					Repo:          repo,
+					Signer:        signer,
+				}, nil
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			opts, err := tc.prepare(tmp)
+			if err != nil {
+				t.Fatalf("test preparation failed: %v", err)
+			}
+
+			env, err := opts.AttestPredicate(context.Background())
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error from AttestPredicate")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AttestPredicate: %v", err)
+			}
+			if len(env) == 0 {
+				t.Fatal("empty envelope")
+			}
+			var e struct {
+				Payload     string `json:"payload"`
+				PayloadType string `json:"payloadType"`
+			}
+			if err := json.Unmarshal(env, &e); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+		})
+	}
+}
+
+func TestWriteEnvelope(t *testing.T) {
+	t.Setenv("COSIGN_PASSWORD", "")
+
+	tmp := t.TempDir()
+	fs := afero.NewMemMapFs()
+	pred := filepath.Join(tmp, "vsa.json")
+	err := afero.WriteFile(fs, pred, []byte(`{"hello":"world"}`), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	key := filepath.Join(tmp, "cosign.key")
+	err = afero.WriteFile(fs, key, []byte(testECKey), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	signer := testSigner(key, fs)
+	opts, _ := NewAttestOptions(pred, repo, digest, signer)
+	env, _ := opts.AttestPredicate(context.Background())
+
+	out, err := opts.WriteEnvelope(env)
+	if err != nil {
+		t.Fatalf("WriteEnvelope: %v", err)
+	}
+	if !filepath.IsAbs(out) {
+		t.Errorf("expected abs path, got %q", out)
+	}
+}

--- a/internal/validate/vsa/vsa.go
+++ b/internal/validate/vsa/vsa.go
@@ -24,11 +24,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci"
-	"github.com/sigstore/cosign/v2/pkg/oci/static"
-	"github.com/sigstore/sigstore/pkg/signature"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
@@ -48,15 +44,19 @@ type Predicate struct {
 }
 
 // Generator handles VSA predicate generation
-type Generator struct{}
+type Generator struct {
+	Report applicationsnapshot.Report
+}
 
 // NewGenerator creates a new VSA predicate generator
-func NewGenerator() *Generator {
-	return &Generator{}
+func NewGenerator(report applicationsnapshot.Report) *Generator {
+	return &Generator{
+		Report: report,
+	}
 }
 
 // GeneratePredicate creates a Predicate for a validated image/component.
-func (g *Generator) GeneratePredicate(ctx context.Context, report applicationsnapshot.Report, comp applicationsnapshot.Component) (*Predicate, error) {
+func (g *Generator) GeneratePredicate(ctx context.Context, comp applicationsnapshot.Component) (*Predicate, error) {
 	log.Infof("Generating VSA predicate for image: %s", comp.ContainerImage)
 
 	// Compose the component info as a map
@@ -78,8 +78,8 @@ func (g *Generator) GeneratePredicate(ctx context.Context, report applicationsna
 	}
 
 	policySource := ""
-	if report.Policy.Name != "" {
-		policySource = report.Policy.Name
+	if g.Report.Policy.Name != "" {
+		policySource = g.Report.Policy.Name
 	}
 
 	return &Predicate{
@@ -157,42 +157,4 @@ func RekorUploader(ctx context.Context, att oci.Signature, location string) (str
 func NoopUploader(ctx context.Context, att oci.Signature, location string) (string, error) {
 	log.Infof("Upload type is 'none'; skipping upload for %s", location)
 	return "", nil
-}
-
-type PrivateKeyLoader func(key []byte, pass []byte) (signature.SignerVerifier, error)
-type AttestationSigner func(ctx context.Context, signer signature.SignerVerifier, ref name.Reference, att oci.Signature, opts *cosign.CheckOpts) (name.Digest, error)
-
-type Signer struct {
-	FS        afero.Fs          // for reading the VSA file
-	KeyLoader PrivateKeyLoader  // injected loader
-	SignFunc  AttestationSigner // injected cosign API
-}
-
-func NewSigner(fs afero.Fs, loader PrivateKeyLoader, signer AttestationSigner) *Signer {
-	return &Signer{
-		FS:        fs,
-		KeyLoader: loader,
-		SignFunc:  signer,
-	}
-}
-
-// Sign reads the file, loads the key, and returns the signature.
-func (s *Signer) Sign(ctx context.Context, vsaPath, keyPath, imageRef string) (oci.Signature, error) {
-	log.Infof("Signing VSA for image: %s", imageRef)
-	vsaData, err := afero.ReadFile(s.FS, vsaPath)
-	if err != nil {
-		log.Errorf("Failed to read VSA file: %v", err)
-		return nil, fmt.Errorf("failed to read VSA file: %w", err)
-	}
-	// TODO: Actually sign the attestation using cosign APIs. For now, just create the attestation object.
-	// Example:
-	// signer, err := s.KeyLoader( /* load key bytes from keyPath */ )
-	// attestationSigned, err := s.SignFunc(ctx, signer, ref, att, nil)
-	att, err := static.NewAttestation(vsaData)
-	if err != nil {
-		log.Errorf("Failed to create attestation: %v", err)
-		return nil, fmt.Errorf("failed to create attestation: %w", err)
-	}
-	log.Infof("VSA attestation (unsigned) created for %s", imageRef)
-	return att, nil
 }

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -25,14 +25,11 @@ import (
 	"time"
 
 	ecapi "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
-	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	v1types "github.com/google/go-containerregistry/pkg/v1/types"
 	appapi "github.com/konflux-ci/application-api/api/v1alpha1"
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v2/pkg/oci"
-	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,8 +38,23 @@ import (
 	"github.com/conforma/cli/internal/evaluator"
 )
 
-// TestSignVSA tests the signing functionality of the Signer.
+// TestSignVSA tests the signing functionality using the new Signer structure from attest.go.
 func TestSignVSA(t *testing.T) {
+	t.Setenv("COSIGN_PASSWORD", "") // key is unencrypted
+
+	// Create test key content
+	testKey := `-----BEGIN ENCRYPTED SIGSTORE PRIVATE KEY-----
+eyJrZGYiOnsibmFtZSI6InNjcnlwdCIsInBhcmFtcyI6eyJOIjo2NTUzNiwiciI6
+OCwicCI6MX0sInNhbHQiOiJLYU9OQzduQVJLOVgxM1FoaWFucjAwTTBGYys2Sitr
+dnAxN1FuanpiVk9nPSJ9LCJjaXBoZXIiOnsibmFtZSI6Im5hY2wvc2VjcmV0Ym94
+Iiwibm9uY2UiOiJVOHZqWWtqMlZOUFZGdlZFZWZ3bXZ5VGloUERrelBoaCJ9LCJj
+aXBoZXJ0ZXh0IjoidWNWMnQ4TTZVNFJvb29FOXc0d3dkc3E1RDYrS2RKY245dERT
+KzFwRDRGN040SVJOWEgzSTBua3h1a3NackFOUHR1emIvTkVYQ201dUp3Zjh3Qzl1
+VlprbXdwNU5jRUZ6b3ZNS3JCZmNvdXdjaEkrMzkrQ0NhbVZPbzBucmRnZjhvcmpK
+dXdrWDBYL1phY0RUTERGaUxyc1laMWVMMmlqMGU1MVRpZmVQNTl4WXNPK1FnM1Jv
+OURRVjNQMk9ndDFDaVFHeGg1VXhUZytGc3c9PSJ9
+-----END ENCRYPTED SIGSTORE PRIVATE KEY-----`
+
 	// Set up test filesystem
 	fs := afero.NewMemMapFs()
 
@@ -61,41 +73,39 @@ func TestSignVSA(t *testing.T) {
 		RuleResults: []evaluator.Result{{Message: "violation1"}},
 	}
 
-	// Write test file
+	// Write test files
 	vsaPath := "/test.vsa.json"
 	data, _ := json.Marshal(pred)
 	err := afero.WriteFile(fs, vsaPath, data, 0600)
 	assert.NoError(t, err)
 
-	// Create mock key loader and signer
-	mockKeyLoader := func(key []byte, pass []byte) (signature.SignerVerifier, error) {
-		return nil, nil // Mock implementation
-	}
-
-	mockSigner := func(ctx context.Context, signer signature.SignerVerifier, ref name.Reference, att oci.Signature, opts *cosign.CheckOpts) (name.Digest, error) {
-		return name.Digest{}, nil // Mock implementation
-	}
-
-	// Create signer instance
-	signer := Signer{
-		FS:        fs,
-		KeyLoader: mockKeyLoader,
-		SignFunc:  mockSigner,
-	}
-
-	// Act
-	sig, err := signer.Sign(context.Background(), vsaPath, "irrelevant.key", "quay.io/test/image:tag")
-	// Assert
+	keyPath := "/test.key"
+	err = afero.WriteFile(fs, keyPath, []byte(testKey), 0600)
 	assert.NoError(t, err)
-	assert.NotNil(t, sig)
-	payload, err := sig.Payload()
-	assert.NoError(t, err)
-	assert.Contains(t, string(payload), "quay.io/test/image:tag")
 
-	// Test error propagation from attestation creation
-	_, err = signer.Sign(context.Background(), "/nonexistent/path", "irrelevant.key", "quay.io/test/image:tag")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read VSA file")
+	// Test successful signing
+	t.Run("successful signing", func(t *testing.T) {
+		signer := testSigner(keyPath, fs)
+
+		opts, err := NewAttestOptions(vsaPath, "quay.io/test/image", "sha256:abcd1234", signer)
+		require.NoError(t, err)
+
+		env, err := opts.AttestPredicate(context.Background())
+		assert.NoError(t, err)
+		assert.NotEmpty(t, env)
+	})
+
+	// Test missing predicate file
+	t.Run("missing predicate file", func(t *testing.T) {
+		signer := testSigner(keyPath, fs)
+
+		opts, err := NewAttestOptions("/nonexistent.json", "quay.io/test/image", "sha256:abcd1234", signer)
+		require.NoError(t, err)
+
+		_, err = opts.AttestPredicate(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "open predicate")
+	})
 }
 
 func TestUploadVSAAttestation(t *testing.T) {
@@ -255,8 +265,8 @@ func TestGeneratePredicate(t *testing.T) {
 	}
 
 	// Create generator and generate predicate
-	generator := NewGenerator()
-	pred, err := generator.GeneratePredicate(context.Background(), report, comp)
+	generator := NewGenerator(report)
+	pred, err := generator.GeneratePredicate(context.Background(), comp)
 	require.NoError(t, err)
 
 	// Verify predicate fields


### PR DESCRIPTION
Introduce VSA signing, which signs a Verification Summary Attestation (VSA) JSON file using a cosign-compatible private key. This builds on top of the VSA generation.

https://issues.redhat.com/browse/EC-1308