### PR TITLE
chore(release): add `snapshot` tag for tekton-bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,12 +145,12 @@ jobs:
       - name: Registry login (quay.io/conforma)
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_CONFORMA }} -p ${{ secrets.BUNDLE_PUSH_PASS_CONFORMA }} quay.io
 
-      - name: Create and push the tekton bundle (quay.io/conforma/ec-task-bundle)
+      - name: Create and push the tekton bundle (quay.io/conforma/tekton-task)
         env:
-          TASK_REPO: quay.io/conforma/ec-task-bundle
+          TASK_REPO: quay.io/conforma/tekton-task
           IMAGE_REPO: quay.io/conforma/cli
           TASKS: "tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
-        run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP" TASKS=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASKS | yq 'select(. != null)')
+        run: make task-bundle-snapshot TASK_REPO=$TASK_REPO TASK_TAG=$TAG ADD_TASK_TAG="$TAG_TIMESTAMP snapshot" TASKS=<( yq e ".spec.steps[].image? = \"$IMAGE_REPO:$TAG\"" $TASKS | yq 'select(. != null)')
 
       - name: Registry login (quay.io/enterprise-contract)
         run: podman login -u ${{ secrets.BUNDLE_PUSH_USER_EC  }} -p ${{ secrets.BUNDLE_PUSH_PASS_EC }} quay.io


### PR DESCRIPTION
This commit adds the `snapshot` tag when pushing the tekton-bundle to the `conforma/tekton-task` registry.

Ref: EC-1110