### PR TITLE
chore: update references to hooks repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 repos:
-  - repo: https://github.com/enterprise-contract/hooks
+  - repo: https://github.com/conforma/hooks
     rev: v0.0.2
     hooks:
       - id: check-commit-message 


### PR DESCRIPTION
This commit updates references to the hooks repository from `enterprise-contract/hooks` to `conforma/hooks`.

Ref: EC-1121