### PR TITLE
Use Konflux built image refs for tekton task & cli image

### DIFF
--- a/.tekton/cli-main-push.yaml
+++ b/.tekton/cli-main-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtap-contract-tenant/ec-main/cli-main:{{revision}}
   - name: bundle-cli-ref-repo
-    value: quay.io/enterprise-contract/cli
+    value: quay.io/conforma/cli
   - name: dockerfile
     value: Dockerfile.dist
   - name: image-expires-after

--- a/release/cli.yaml
+++ b/release/cli.yaml
@@ -114,7 +114,7 @@ spec:
     taskRef:
       params:
       - name: bundle
-        value: quay.io/enterprise-contract/ec-task-bundle:snapshot
+        value: quay.io/conforma/tekton-task:latest
       - name: kind
         value: task
       - name: name
@@ -139,7 +139,7 @@ spec:
     taskRef:
       params:
       - name: bundle
-        value: quay.io/enterprise-contract/ec-task-bundle:snapshot
+        value: quay.io/conforma/tekton-task:latest
       - name: kind
         value: task
       - name: name

--- a/release/setup.yaml
+++ b/release/setup.yaml
@@ -22,8 +22,12 @@ metadata:
   name: tenant-release
   namespace: rhtap-contract-tenant
 secrets:
-  - name: ec-cli-main  # push quay.io/enterprise-contract/cli
-  - name: ec-tekton-task-main  # push quay.io/enterprise-contract/tekton-task
+  # Push credential for quay.io/conforma/cli
+  # and quay.io/enterprise-contract/cli
+  - name: ec-cli-main
+  # Push credential for quay.io/conforma/tekton-task
+  # and quay.io/enterprise-contract/tekton-task
+  - name: ec-tekton-task-main
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -201,7 +201,7 @@ spec:
       image: quay.io/redhat-appstudio/build-trusted-artifacts:e02102ede09aa07187cba066ad547a54724e5cf4
 
     - name: initialize-tuf
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       script: |-
         set -euo pipefail
 
@@ -229,12 +229,12 @@ spec:
           value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE_NS)
         - name: SNAPSHOT_PATH
           value: $(params.HOMEDIR)/snapshot.json
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [reduce-snapshot.sh]
 
     - name: validate
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [ec]
       args:
@@ -297,7 +297,7 @@ spec:
           readOnly: true
 
     - name: report-json
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [sh, -c]
       args:
@@ -310,7 +310,7 @@ spec:
         - "jq . $(params.HOMEDIR)/report-json.json | awk '{gsub(/^ +/, \"\"); acc += length; if (acc >= 8000) { printf \"\\n\"; acc=length } printf $0 }'"
 
     - name: summary
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [jq]
       args:
@@ -318,26 +318,26 @@ spec:
         - "$(results.TEST_OUTPUT.path)"
 
     - name: info
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [printf]
       args:
         - "----- DEBUG OUTPUT -----\n"
 
     - name: version
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [ec]
       args:
         - version
 
     - name: show-config
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [jq]
       args:
         - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
         - "$(params.HOMEDIR)/report-json.json"
 
     - name: assert
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [jq]
       args:
         - "--argjson"

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -179,7 +179,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [ec]
       args:
         - sigstore
@@ -211,12 +211,12 @@ spec:
           value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE_NS)
         - name: SNAPSHOT_PATH
           value: $(params.HOMEDIR)/snapshot.json
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [reduce-snapshot.sh]
 
     - name: validate
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [ec]
       args:
@@ -284,7 +284,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [sh, -c]
       args:
@@ -303,7 +303,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [jq]
       args:
@@ -317,7 +317,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [printf]
       args:
         - "----- DEBUG OUTPUT -----\n"
@@ -329,7 +329,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [ec]
       args:
         - version
@@ -341,7 +341,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [jq]
       args:
         - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
@@ -354,7 +354,7 @@ spec:
           memory: 256Mi
         limits:
           memory: 256Mi
-      image: quay.io/conforma/cli:snapshot
+      image: quay.io/conforma/cli:latest
       command: [jq]
       args:
         - "--argjson"


### PR DESCRIPTION
Note that the old repos are still being updated, and still work fine, it's just that they're built and pushed using GitHub workflows instead of using Konflux pipelines. The Konflux built images are preferred, so let's use them consistently.

Ref: https://issues.redhat.com/browse/EC-1255