### PR TITLE
chore: update references to github-workflows repo

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -22,7 +22,7 @@ name: 'Auto merge'
 
 jobs:
   auto-merge:
-    uses: enterprise-contract/github-workflows/.github/workflows/auto-merge.yaml@main
+    uses: conforma/github-workflows/.github/workflows/auto-merge.yaml@main
     secrets: inherit
     permissions:
       pull-requests: write

--- a/.github/workflows/checks-codecov.yaml
+++ b/.github/workflows/checks-codecov.yaml
@@ -61,7 +61,7 @@ jobs:
           cache: false
 
       - name: Check go versions
-        uses: enterprise-contract/github-workflows/golang-version-check@main
+        uses: conforma/github-workflows/golang-version-check@main
 
       - name: Generate
         run: make generate

--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -70,7 +70,7 @@ jobs:
           cache: false
 
       - name: Check go versions
-        uses: enterprise-contract/github-workflows/golang-version-check@main
+        uses: conforma/github-workflows/golang-version-check@main
 
       - name: Download SeaLights Go agent and CLI tool
         run: |


### PR DESCRIPTION
This commit updates references to the github-workflows repository from `enterprise-contract/github-workflows` to `conforma/github-workflows`.

Ref: EC-1118