### PR TITLE
Update rule doc url generated by "ec inspect"

### DIFF
--- a/docs/modules/ROOT/pages/signing.adoc
+++ b/docs/modules/ROOT/pages/signing.adoc
@@ -7,7 +7,7 @@ command.
 == Image Verification
 
 When Conforma validates an image, there are certain
-https://conforma.dev/docs/policy/release_policy.html#builtin_attestation_package[builtin]
+https://conforma.dev/docs/policy/packages/release_builtin_attestation.html[builtin]
 policy rules that are always applied and cannot be skipped. Most of these rely on
 https://github.com/sigstore/cosign[cosign] to fetch and verify image signatures and attestations.
 These meta artifacts are associated to the underlying container image by digest. This has two

--- a/features/__snapshots__/inspect_policy.snap
+++ b/features/__snapshots__/inspect_policy.snap
@@ -52,7 +52,7 @@ Error: Merge error. The 'rule_data' key was found more than once!
 # Source: git::${GITHOST}/git/policy.git?ref=${LATEST_COMMIT}
 
 kitty.purr (deny)
-https://conforma.dev/docs/policy/release_policy.html#kitty__purr
+https://conforma.dev/docs/policy/packages/release_kitty.html#kitty__purr
 Kittens
 Fluffy
 --
@@ -89,20 +89,20 @@ kitty.purr
 # Source: git::${GITHOST}/git/policy1.git?ref=f81eaf65be8da58460ff920408ba1313051184a1
 
 kitty.purr (deny)
-https://conforma.dev/docs/policy/release_policy.html#kitty__purr
+https://conforma.dev/docs/policy/packages/release_kitty.html#kitty__purr
 Kittens
 Fluffy
 --
 # Source: git::${GITHOST}/git/policy2.git?ref=${LATEST_COMMIT}
 
 main.rejector (deny)
-https://conforma.dev/docs/policy/release_policy.html#main__rejector
+https://conforma.dev/docs/policy/packages/release_main.html#main__rejector
 Reject rule
 This rule will always fail
 [A]
 --
 main.reject_with_term (deny)
-https://conforma.dev/docs/policy/release_policy.html#main__reject_with_term
+https://conforma.dev/docs/policy/packages/release_main.html#main__reject_with_term
 Reject with term rule
 This rule will always fail
 [A]

--- a/internal/evaluator/conftest_evaluator_test.go
+++ b/internal/evaluator/conftest_evaluator_test.go
@@ -1422,7 +1422,7 @@ func TestCollectAnnotationData(t *testing.T) {
 			Package:          "a.b.c",
 			ShortName:        "short",
 			Title:            "Title",
-			DocumentationUrl: "https://conforma.dev/docs/policy/release_policy.html#c__short",
+			DocumentationUrl: "https://conforma.dev/docs/policy/packages/release_c.html#c__short",
 		},
 	}, rules)
 }

--- a/internal/opa/output_test.go
+++ b/internal/opa/output_test.go
@@ -66,7 +66,7 @@ func Test_RegoTextOutput(t *testing.T) {
 				# Source: spam.io/bacon-bundle
 
 				policy.foo.bar.rule_title (deny)
-				https://conforma.dev/docs/policy/release_policy.html#bar__rule_title
+				https://conforma.dev/docs/policy/packages/release_bar.html#bar__rule_title
 				Rule title
 				Rule description
 				--

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -214,7 +214,7 @@ func documentationUrl(a *ast.AnnotationsRef) string {
 	// Given all this, the documentationUrl is not really reliable. We could remove it
 	// entirely, but since it's used only the `ec inspect policy` output, let's live
 	// with its flaws for now and fix it later.
-	ruleDocUrlFormat := "https://conforma.dev/docs/policy/release_policy.html#%s__%s"
+	ruleDocUrlFormat := "https://conforma.dev/docs/policy/packages/release_%s.html#%s__%s"
 
 	// a.Path might be something like this: "data.foo.deny" or
 	// "data.some.path.foo.warn". We want to pick out just "foo".
@@ -224,7 +224,8 @@ func documentationUrl(a *ast.AnnotationsRef) string {
 	shortName := shortName(a)
 
 	if lenPathStrings > 2 && pathStrings[lenPathStrings-2] != "" && shortName != "" {
-		return fmt.Sprintf(ruleDocUrlFormat, pathStrings[lenPathStrings-2], shortName)
+		packageName := pathStrings[lenPathStrings-2]
+		return fmt.Sprintf(ruleDocUrlFormat, packageName, packageName, shortName)
 	}
 
 	return ""

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -478,7 +478,7 @@ func TestCodeAndDocumentationUrl(t *testing.T) {
 				#   short_name: x
 				deny if { true }`)),
 			expected:    "a.x",
-			expectedUrl: "https://conforma.dev/docs/policy/release_policy.html#a__x",
+			expectedUrl: "https://conforma.dev/docs/policy/packages/release_a.html#a__x",
 		},
 		{
 			name: "nested packages no annotations",
@@ -499,7 +499,7 @@ func TestCodeAndDocumentationUrl(t *testing.T) {
 				#   short_name: x
 				deny if { true }`)),
 			expected:    "a.b.c.x",
-			expectedUrl: "https://conforma.dev/docs/policy/release_policy.html#c__x",
+			expectedUrl: "https://conforma.dev/docs/policy/packages/release_c.html#c__x",
 		},
 	}
 


### PR DESCRIPTION
Following a split up of policy pages in Conforma docs, there is a dedicated page for each policy package.
Adjust rule doc url generation accordingly.

Also updated doc links in various places.