### PR TITLE
refactor: migrate application snapshot VSA to per-image implementatio…

### DIFF
--- a/internal/applicationsnapshot/digest.go
+++ b/internal/applicationsnapshot/digest.go
@@ -14,25 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package vsa
+package applicationsnapshot
 
 import (
-	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/spf13/afero"
 )
 
-// PredicateGenerator interface for generating VSA predicates
-type PredicateGenerator[T any] interface {
-	GeneratePredicate(ctx context.Context) (T, error)
-}
-
-// PredicateWriter interface for writing VSA predicates to files
-type PredicateWriter[T any] interface {
-	WritePredicate(pred T) (string, error)
-}
-
-// PredicateAttestor interface for attesting VSA predicates and writing envelopes
-type PredicateAttestor interface {
-	AttestPredicate(ctx context.Context) ([]byte, error)
-	WriteEnvelope(data []byte) (string, error)
-	TargetDigest() string
+// GetVSAPredicateDigest calculates the sha256 digest of the given file path.
+func GetVSAPredicateDigest(fs afero.Fs, path string) (string, error) {
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data)), nil
 }

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -18,6 +18,7 @@ package applicationsnapshot
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"encoding/json"
 	"encoding/xml"
@@ -219,11 +220,12 @@ func (r *Report) toFormat(format string) (data []byte, err error) {
 }
 
 func (r *Report) toVSA() ([]byte, error) {
-	vsa, err := NewVSA(*r)
+	generator := NewSnapshotVSAGenerator(*r)
+	predicate, err := generator.GeneratePredicate(context.Background())
 	if err != nil {
 		return []byte{}, err
 	}
-	return json.Marshal(vsa)
+	return json.Marshal(predicate)
 }
 
 // toSummary returns a condensed version of the report.

--- a/internal/validate/vsa/attest_test.go
+++ b/internal/validate/vsa/attest_test.go
@@ -187,7 +187,7 @@ func TestAttestPredicate(t *testing.T) {
 				return Attestor{
 					PredicatePath: pred,
 					PredicateType: "https://enterprisecontract.dev/attestations/vsa/v1",
-					ImageDigest:   digest,
+					Digest:        digest,
 					Repo:          repo,
 					Signer:        signer,
 				}, nil
@@ -206,7 +206,7 @@ func TestAttestPredicate(t *testing.T) {
 				return Attestor{
 					PredicatePath: filepath.Join(tmp, "no.json"),
 					PredicateType: "https://enterprisecontract.dev/attestations/vsa/v1",
-					ImageDigest:   digest,
+					Digest:        digest,
 					Repo:          repo,
 					Signer:        signer,
 				}, nil

--- a/internal/validate/vsa/orchestrator.go
+++ b/internal/validate/vsa/orchestrator.go
@@ -19,13 +19,11 @@ package vsa
 import (
 	"context"
 	"fmt"
-
-	"github.com/conforma/cli/internal/applicationsnapshot"
 )
 
 // GenerateAndWriteVSA generates a VSA predicate and writes it to a file, returning the written path.
-func GenerateAndWriteVSA(ctx context.Context, generator PredicateGenerator, writer PredicateWriter, comp applicationsnapshot.Component) (string, error) {
-	pred, err := generator.GeneratePredicate(ctx, comp)
+func GenerateAndWriteVSA[T any](ctx context.Context, generator PredicateGenerator[T], writer PredicateWriter[T]) (string, error) {
+	pred, err := generator.GeneratePredicate(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -36,15 +34,15 @@ func GenerateAndWriteVSA(ctx context.Context, generator PredicateGenerator, writ
 	return writtenPath, nil
 }
 
-// AttestVSA handles VSA attestation and envelope writing for a single component.
-func AttestVSA(ctx context.Context, attestor PredicateAttestor, comp applicationsnapshot.Component) (string, error) {
+// AttestVSA handles VSA attestation and envelope writing for the target component.
+func AttestVSA(ctx context.Context, attestor PredicateAttestor) (string, error) {
 	env, err := attestor.AttestPredicate(ctx)
 	if err != nil {
-		return "", fmt.Errorf("[VSA] Error attesting VSA for image %s: %w", comp.ContainerImage, err)
+		return "", fmt.Errorf("[VSA] Error attesting VSA for artifact %s: %w", attestor.TargetDigest(), err)
 	}
 	envelopePath, err := attestor.WriteEnvelope(env)
 	if err != nil {
-		return "", fmt.Errorf("[VSA] Error writing envelope for image %s: %w", comp.ContainerImage, err)
+		return "", fmt.Errorf("[VSA] Error writing envelope for artifact %s: %w", attestor.TargetDigest(), err)
 	}
 	return envelopePath, nil
 }

--- a/internal/validate/vsa/service.go
+++ b/internal/validate/vsa/service.go
@@ -1,0 +1,132 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+
+	"github.com/conforma/cli/internal/applicationsnapshot"
+)
+
+// Service encapsulates all VSA processing logic for both components and snapshots
+type Service struct {
+	signer *Signer
+	fs     afero.Fs
+}
+
+// NewServiceWithFS creates a new VSA service with the given signer and filesystem
+func NewServiceWithFS(signer *Signer, fs afero.Fs) *Service {
+	return &Service{
+		signer: signer,
+		fs:     fs,
+	}
+}
+
+// ProcessComponentVSA processes VSA generation, writing, and attestation for a single component
+func (s *Service) ProcessComponentVSA(ctx context.Context, report applicationsnapshot.Report, comp applicationsnapshot.Component, gitURL, digest string) (string, error) {
+	generator := NewGenerator(report, comp)
+	writer := &Writer{
+		FS:            s.fs,
+		TempDirPrefix: "vsa-",
+		FilePerm:      0o600,
+	}
+
+	// Generate and write VSA predicate
+	writtenPath, err := GenerateAndWriteVSA(ctx, generator, writer)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate and write component VSA: %w", err)
+	}
+
+	// Create attestor and attest VSA
+	attestor, err := NewAttestor(writtenPath, gitURL, digest, s.signer)
+	if err != nil {
+		return "", fmt.Errorf("failed to create component attestor: %w", err)
+	}
+
+	envelopePath, err := AttestVSA(ctx, attestor)
+	if err != nil {
+		return "", fmt.Errorf("failed to attest component VSA: %w", err)
+	}
+
+	log.Infof("[VSA] Component VSA attested and envelope written to %s", envelopePath)
+	return envelopePath, nil
+}
+
+// ProcessSnapshotVSA processes VSA generation, writing, and attestation for the application snapshot
+func (s *Service) ProcessSnapshotVSA(ctx context.Context, report applicationsnapshot.Report) (string, error) {
+	generator := applicationsnapshot.NewSnapshotVSAGenerator(report)
+	writer := applicationsnapshot.NewSnapshotVSAWriter()
+	writer.FS = s.fs
+
+	// Generate and write VSA predicate
+	writtenPath, err := GenerateAndWriteVSA(ctx, generator, writer)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate and write snapshot VSA: %w", err)
+	}
+
+	// Calculate digest for the snapshot VSA predicate
+	digest, err := applicationsnapshot.GetVSAPredicateDigest(s.fs, writtenPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate digest for snapshot VSA: %w", err)
+	}
+
+	// Create attestor and attest VSA
+	attestor, err := NewAttestor(writtenPath, "", digest, s.signer)
+	if err != nil {
+		return "", fmt.Errorf("failed to create snapshot attestor: %w", err)
+	}
+
+	envelopePath, err := AttestVSA(ctx, attestor)
+	if err != nil {
+		return "", fmt.Errorf("failed to attest snapshot VSA: %w", err)
+	}
+
+	log.Infof("[VSA] Snapshot VSA attested and envelope written to %s", envelopePath)
+	return envelopePath, nil
+}
+
+// ProcessAllVSAs processes VSAs for all components and the snapshot
+func (s *Service) ProcessAllVSAs(ctx context.Context, report applicationsnapshot.Report, getGitURL func(applicationsnapshot.Component) string, getDigest func(applicationsnapshot.Component) (string, error)) error {
+	// Process VSAs for all components
+	for _, comp := range report.Components {
+		gitURL := getGitURL(comp)
+		digest, err := getDigest(comp)
+		if err != nil {
+			log.Errorf("Failed to get digest for component %s: %v", comp.ContainerImage, err)
+			continue
+		}
+
+		_, err = s.ProcessComponentVSA(ctx, report, comp, gitURL, digest)
+		if err != nil {
+			log.Errorf("Failed to process VSA for component %s: %v", comp.ContainerImage, err)
+			continue
+		}
+	}
+
+	// Process VSA for the snapshot
+	_, err := s.ProcessSnapshotVSA(ctx, report)
+	if err != nil {
+		log.Errorf("Failed to process snapshot VSA: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/validate/vsa/service_test.go
+++ b/internal/validate/vsa/service_test.go
@@ -1,0 +1,178 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"testing"
+
+	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	app "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/conforma/cli/internal/applicationsnapshot"
+	"github.com/conforma/cli/internal/evaluator"
+)
+
+func TestService_ProcessComponentVSA(t *testing.T) {
+	ctx := context.Background()
+	fs := afero.NewMemMapFs()
+
+	// Create test data
+	report := applicationsnapshot.Report{
+		Success: true,
+		Policy:  ecc.EnterpriseContractPolicySpec{},
+	}
+
+	comp := applicationsnapshot.Component{
+		SnapshotComponent: app.SnapshotComponent{
+			Name:           "test-component",
+			ContainerImage: "quay.io/test/image:tag",
+		},
+		Success:    true,
+		Violations: []evaluator.Result{},
+		Warnings:   []evaluator.Result{},
+		Successes:  []evaluator.Result{{Message: "test success"}},
+	}
+
+	// Create test signer
+	signer := testSigner("/test.key", fs)
+	service := NewServiceWithFS(signer, fs)
+
+	// Test successful processing
+	envelopePath, err := service.ProcessComponentVSA(ctx, report, comp, "https://github.com/test/repo", "sha256:testdigest")
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, envelopePath)
+	assert.Contains(t, envelopePath, ".intoto.jsonl")
+}
+
+func TestService_ProcessSnapshotVSA(t *testing.T) {
+	ctx := context.Background()
+	fs := afero.NewMemMapFs()
+
+	// Create test data
+	report := applicationsnapshot.Report{
+		Success: true,
+		Policy:  ecc.EnterpriseContractPolicySpec{},
+		Components: []applicationsnapshot.Component{
+			{
+				SnapshotComponent: app.SnapshotComponent{
+					Name:           "test-component",
+					ContainerImage: "quay.io/test/image:tag",
+				},
+				Success: true,
+			},
+		},
+	}
+
+	// Create test signer
+	signer := testSigner("/test.key", fs)
+	service := NewServiceWithFS(signer, fs)
+
+	// Test successful processing
+	envelopePath, err := service.ProcessSnapshotVSA(ctx, report)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, envelopePath)
+	assert.Contains(t, envelopePath, ".intoto.jsonl")
+}
+
+func TestService_ProcessAllVSAs(t *testing.T) {
+	ctx := context.Background()
+	fs := afero.NewMemMapFs()
+
+	// Create test data
+	report := applicationsnapshot.Report{
+		Success: true,
+		Policy:  ecc.EnterpriseContractPolicySpec{},
+		Components: []applicationsnapshot.Component{
+			{
+				SnapshotComponent: app.SnapshotComponent{
+					Name:           "test-component-1",
+					ContainerImage: "quay.io/test/image1:tag",
+				},
+				Success: true,
+			},
+			{
+				SnapshotComponent: app.SnapshotComponent{
+					Name:           "test-component-2",
+					ContainerImage: "quay.io/test/image2:tag",
+				},
+				Success: true,
+			},
+		},
+	}
+
+	// Create test signer
+	signer := testSigner("/test.key", fs)
+	service := NewServiceWithFS(signer, fs)
+
+	// Define helper functions
+	getGitURL := func(comp applicationsnapshot.Component) string {
+		return "https://github.com/test/repo"
+	}
+
+	getDigest := func(comp applicationsnapshot.Component) (string, error) {
+		return "sha256:testdigest", nil
+	}
+
+	// Test successful processing
+	err := service.ProcessAllVSAs(ctx, report, getGitURL, getDigest)
+
+	assert.NoError(t, err)
+}
+
+func TestService_ProcessAllVSAs_WithErrors(t *testing.T) {
+	ctx := context.Background()
+	fs := afero.NewMemMapFs()
+
+	// Create test data
+	report := applicationsnapshot.Report{
+		Success: true,
+		Policy:  ecc.EnterpriseContractPolicySpec{},
+		Components: []applicationsnapshot.Component{
+			{
+				SnapshotComponent: app.SnapshotComponent{
+					Name:           "test-component-1",
+					ContainerImage: "quay.io/test/image1:tag",
+				},
+				Success: true,
+			},
+		},
+	}
+
+	// Create test signer
+	signer := testSigner("/test.key", fs)
+	service := NewServiceWithFS(signer, fs)
+
+	// Define helper functions that return errors
+	getGitURL := func(comp applicationsnapshot.Component) string {
+		return "https://github.com/test/repo"
+	}
+
+	getDigest := func(comp applicationsnapshot.Component) (string, error) {
+		return "", assert.AnError
+	}
+
+	// Test processing with errors (should continue processing other components)
+	err := service.ProcessAllVSAs(ctx, report, getGitURL, getDigest)
+
+	// Should still succeed overall, but log errors for individual components
+	assert.NoError(t, err)
+}

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -265,8 +265,8 @@ func TestGeneratePredicate(t *testing.T) {
 	}
 
 	// Create generator and generate predicate
-	generator := NewGenerator(report)
-	pred, err := generator.GeneratePredicate(context.Background(), comp)
+	generator := NewGenerator(report, comp)
+	pred, err := generator.GeneratePredicate(context.Background())
 	require.NoError(t, err)
 
 	// Verify predicate fields


### PR DESCRIPTION
- Refactored ApplicationSnapshot VSA generation to use the per-image VSA generation logic
- Simplified snapshot-level VSA flow by reusing component-level signing implementation
- Added support for signing ApplicationSnapshot VSAs using the same key and process as per-image VSAs
- Removed legacy snapshot-specific logic that is now redundant

https://issues.redhat.com/browse/EC-1359

Co-authored-by: OpenAI GPT-4.1 <gpt-4.1@openai.com>