### PR TITLE
feat(ci): add prefixes to distinguish image tags by build system

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
 
     env:
       IMAGE_REPO: quay.io/conforma/cli
-      TAG: ${{ github.sha }}
+      TAG: gh-${{ github.sha }}
       TAG_TIMESTAMP: ${{ github.sha }}-${{ needs.info.outputs.timestamp }}
 
     steps:

--- a/hack/copy-snapshot-image.sh
+++ b/hack/copy-snapshot-image.sh
@@ -32,7 +32,7 @@ IMAGE_REF="$(echo "${SNAPSHOT_SPEC}" | jq -r '.components[0].containerImage')"
 
 TAGS=(
     'latest'
-    "${GIT_SHA}"
+    "kf-${GIT_SHA}"
 )
 for tag in "${TAGS[@]}"; do
     echo "Pushing image with tag ${tag}"


### PR DESCRIPTION
Add prefixes to image tags to differentiate between GitHub and Konflux built images:

- GitHub built images use `gh-` prefix for commit hash tags
- Konflux built images use `kf-` prefix for commit hash tags

This change ensures that SHA based image tags clearly indicate their build origin while maintaining existing functionality for rolling tags like `snapshot` and `latest`.

Ref: EC-1188
Assisted-by: claude-4-sonnet