### PR TITLE
Remove gh- tag prefix temporarily

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
 
     env:
       IMAGE_REPO: quay.io/conforma/cli
-      TAG: gh-${{ github.sha }}
+      TAG: ${{ github.sha }}
       TAG_TIMESTAMP: ${{ github.sha }}-${{ needs.info.outputs.timestamp }}
 
     steps:


### PR DESCRIPTION
There's a regex bug causing major chaos to the $TARGETOS value in the Makefile because of this prefix.

As far as I know the kf- prefix isn't causing problems, so let's keep that one.

Ref: https://issues.redhat.com/browse/EC-1373