### PR TITLE
Update golang version from 1.23.6 to 1.24.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.6
+golang 1.24.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ## Build
 
-FROM docker.io/library/golang:1.23.6 AS build
+FROM docker.io/library/golang:1.24.4 AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -16,7 +16,7 @@
 
 ## Build
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6@sha256:e0ad156b08e0b50ad509d79513e13e8a31f2812c66e9c48c98cea53420ec2bca AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4@sha256:a90b4605b47c396c74de55f574d0f9e03b24ca177dec54782f86cdf702c97dbc AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/conforma/cli/acceptance
 
-go 1.23.6
+go 1.24.4
 
 require (
 	cuelang.org/go v0.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conforma/cli
 
-go 1.23.6
+go 1.24.4
 
 require (
 	cuelang.org/go v0.11.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/conforma/cli/tools
 
-go 1.23.6
+go 1.24.4
 
 require (
 	github.com/daixiang0/gci v0.13.5

--- a/tools/kubectl/go.mod
+++ b/tools/kubectl/go.mod
@@ -1,6 +1,6 @@
 module github.com/conforma/cli/tools/kubectl
 
-go 1.23.6
+go 1.24.4
 
 require k8s.io/kubernetes v1.31.6
 


### PR DESCRIPTION
I'm aiming to make it consistent across all the go.mod files.

(My primary goal is to update the opa, but I expect it will bring in some newer dependencies, some of which will require a golang update, so I figured why get this out of the way first.)

Ref: https://issues.redhat.com/browse/EC-1130