### PR TITLE
Fix sealights job dependencies name

### DIFF
--- a/.github/workflows/checks-sealights.yaml
+++ b/.github/workflows/checks-sealights.yaml
@@ -158,7 +158,7 @@ jobs:
 
   Acceptance-SL:
     runs-on: ubuntu-latest
-    needs: [Initialize, Test]
+    needs: [Initialize, Test-SL]
     env:
       BSID: ${{ needs.Initialize.outputs.bsid }}
       SEALIGHTS_LOG_LEVEL: none


### PR DESCRIPTION
This is a fixup for 7b0af0e0 where I renamed the sealights jobs but forgot to name the dependencies accordingly.