### PR TITLE
feat(report): add documentation link to report

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -1991,6 +1991,7 @@ Results:
   Title: Allow rule
   Description: This rule will never fail
 
+For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/
 
 ---
 [future failure is a deny when using effective-date flag:stdout - 1]
@@ -4834,6 +4835,7 @@ Results:
   ImageRef: ${REGISTRY}/acceptance/image@sha256:${REGISTRY_acceptance/image:latest_DIGEST}
   Reason: Fails always
 
+For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/
 
 ---
 

--- a/internal/applicationsnapshot/__snapshots__/report_test.snap
+++ b/internal/applicationsnapshot/__snapshots__/report_test.snap
@@ -155,5 +155,6 @@ Results:
 ✓ [Success] success-2
   ImageRef: registry.io/repository/component-4:tag
 
+For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/
 
 ---

--- a/internal/applicationsnapshot/templates/text_report.tmpl
+++ b/internal/applicationsnapshot/templates/text_report.tmpl
@@ -21,3 +21,7 @@ Results:{{ nl -}}
   {{- template "_results.tmpl" (toMap "Components" $c "Type" "Success") -}}
 {{- end -}}
 {{- end -}}
+
+{{- if or (gt $t.Failures 0) (gt $t.Warnings 0) -}}
+For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/{{ nl -}}
+{{- end -}}

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -222,7 +222,7 @@ func documentationUrl(a *ast.AnnotationsRef) string {
 
 	// This makes assumptions about the way we publish policy docs for
 	// policies defined in https://github.com/conforma/policy/
-	// to https://conforma.dev/docs/policy/index.html . We should figure
+	// to https://conforma.dev/docs/policy/ . We should figure
 	// out a way for the documentationUrl to be configurable, perhaps by using
 	// some additional package annotations. To make matters even worse, we're now
 	// hard coding "release_policy" in the URL, which is guaranteed wrong for


### PR DESCRIPTION
This commit adds a documentation link to text reports when there are policy warnings or failures in an effort to help users find more information about resolving issues.

The link appears at the end of text reports with the message: "For more information about policy issues, see the policy documentation: https://conforma.dev/docs/policy/index.html"

This message is shown when:
- There are warnings
- There are failures
- There are both warnings and failures

REF: EC-1374