### PR TITLE
Remove hardcoded worker count

### DIFF
--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -55,10 +55,10 @@ paths can be provided by using the `:` separator.
 *EXTRA_RULE_DATA* (`string`):: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..."
 *TIMEOUT* (`string`):: This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
 
-*WORKERS* (`string`):: Number of parallel workers to use for policy evaluation. This parameter is currently not used. All policy evaluations are run with 35 workers.
+*WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 
 +
-*Default*: `35`
+*Default*: `4`
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +
 *Default*: `false`

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -128,9 +128,8 @@ spec:
     - name: WORKERS
       type: string
       description: >
-        Number of parallel workers to use for policy evaluation. This parameter is currently not used. All
-        policy evaluations are run with 35 workers.
-      default: "35"
+        Number of parallel workers to use for policy evaluation.
+      default: "4"
 
     - name: SINGLE_COMPONENT
       description: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
@@ -275,8 +274,7 @@ spec:
         - "$(params.REKOR_HOST)"
         - "--ignore-rekor=$(params.IGNORE_REKOR)"
         - "--workers"
-        # NOTE: This value is temporarily hardcoded instead of using the WORKERS parameter.
-        - "35"
+        - "$(params.WORKERS)"
         # NOTE: The syntax below is required to negate boolean parameters
         - "--info=$(params.INFO)"
         # Fresh versions of ec support "--timeout=0" to indicate no timeout, but this would break
@@ -322,9 +320,9 @@ spec:
       computeResources:
         requests:
           cpu: 250m
-          memory: 8Gi
+          memory: 2Gi
         limits:
-          memory: 8Gi
+          memory: 2Gi
       volumeMounts:
         - name: trusted-ca
           mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt


### PR DESCRIPTION
The workers is now configurable from the release
side. So we need to set the worker count using
the task param.

Release task
- https://issues.redhat.com/browse/RELEASE-1765 
Conforma task
- https://issues.redhat.com/browse/EC-1371