### PR TITLE
Update refs to the deprecated attestation_task_bundle package

### DIFF
--- a/.tekton/cli-main-pull-request.yaml
+++ b/.tekton/cli-main-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
 
-      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/policy/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
       This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
     finally: []
     params:

--- a/.tekton/cli-main-push.yaml
+++ b/.tekton/cli-main-push.yaml
@@ -45,7 +45,7 @@ spec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
 
-      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/policy/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
       This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
     finally: []
     params:

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -295,7 +295,7 @@ sources:
       include:
         - "@minimal"
       exclude:
-        - attestation_task_bundle
+        - attestation_type
         - slsa_build_scripted_build
 ----
 JSON::
@@ -309,7 +309,7 @@ JSON::
             "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
                 "include": ["@minimal"],
-                "exclude": ["attestation_task_bundle", "slsa_build_scripted_build"]
+                "exclude": ["attestation_type", "slsa_build_scripted_build"]
             }
         }
     ]
@@ -358,9 +358,9 @@ JSON::
 
 === Excluding just one rule
 
-This would include all rules except for the `unacceptable_task_bundle` rule in
-the `attestation_task_bundle` package. The other rules in the
-`attestation_task_bundle` would be included.
+This would include all rules except for the `pipelinerun_attestation_found` rule in
+the `attestation_type` package. The other rules in the `attestation_type` would
+be included.
 
 [tabs]
 ====
@@ -375,7 +375,7 @@ sources:
       - git::https://github.com/conforma/policy//example/data
     config:
       exclude:
-        - attestation_task_bundle.unacceptable_task_bundle
+        - attestation_type.pipelinerun_attestation_found
 ----
 JSON::
 +
@@ -387,7 +387,7 @@ JSON::
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
             "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
-                "exclude": ["attestation_task_bundle.unacceptable_task_bundle"]
+                "exclude": ["attestation_type.pipelinerun_attestation_found"]
             }
         }
     ]
@@ -439,9 +439,9 @@ JSON::
 You can specify both `include` and `exclude` to pick out just the
 rules you want.
 
-This example specifies that only the `unacceptable_task_bundle` rule from the
-`attestation_task_bundle` package should be included. The other rules in the
-`attestation_task_bundle` would be excluded.
+This example specifies that only the `pipelinerun_attestation_found` rule from the
+`attestation_type` package should be included. The other rules in the
+`attestation_type` would be excluded.
 
 Notice the higher specificity include rule takes precedence over the exclude
 rule in this example.
@@ -460,9 +460,9 @@ sources:
     config:
       include:
         - *
-        - attestation_task_bundle.unacceptable_task_bundle
+        - attestation_type.pipelinerun_attestation_found
       exclude:
-        - attestation_task_bundle.*
+        - attestation_type.*
 ----
 JSON::
 +
@@ -474,8 +474,8 @@ JSON::
             "policy": ["oci::quay.io/enterprise-contract/ec-release-policy:latest"],
             "data": ["git::https://github.com/conforma/policy//example/data"],
             "config": {
-                "include": ["*", "attestation_task_bundle.unacceptable_task_bundle"],
-                "exclude": ["attestation_task_bundle.*"]
+                "include": ["*", "attestation_type.pipelinerun_attestation_found"],
+                "exclude": ["attestation_type.*"]
             }
         }
     ]

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -46,7 +46,7 @@ The strings in the list should be one of the following:
 A "package name"::
 
 Package names can be found in the policy documentation, for example the
-xref:policy:ROOT:release_policy.adoc#attestation_type_package[Attestation Type] package
+xref:policy:ROOT:packages/release_attestation_type.adoc[Attestation Type] package
 name is `attestation_type`. Specifing a package name by itself in the include
 or exclude list means every rule from that package should be included or
 excluded.
@@ -55,15 +55,15 @@ A "rule name"::
 
 A rule name consists of the rule's package name and the rule's "code" separated
 by a dot. Rule codes can be see in the documentation also. For example the
-xref:policy:ROOT:release_policy.adoc#attestation_type__unknown_att_type[Unknown attestation type found] rule
-name is `attestation_type.unknown_att_type`.
+xref:policy:ROOT:packages/release_attestation_type.adoc#attestation_type__known_attestation_type[Known attestation type found] rule
+name is `attestation_type.known_attestation_type`.
 
 A "package name:term"::
 
 Some policy rules process a list of items, "term" allows a particular item to
 be excluded or included. This matcher behaves like "package name" but only
 applies to policy rules in the package that match the "term". For example, the
-xref:policy:ROOT:release_policy.adoc#test_package[Test package] emits results for each
+xref:policy:ROOT:packages/release_test.adoc[Test package] emits results for each
 test case. A particular test case can be ignored without ignoring the remaining
 ones.
 

--- a/docs/modules/ROOT/pages/signing.adoc
+++ b/docs/modules/ROOT/pages/signing.adoc
@@ -62,7 +62,7 @@ expression match if additional flexibility is needed.
 
 Any certificate involved in the signature is also provided as xref:policy_input.adoc[policy input].
 Use this data to establish a fine-grained verification process by leveraging rego policies. See the
-xref:policy:ROOT:release_policy.adoc#github_certificate_package[GitHub Certificate Checks] as
+xref:policy:ROOT:packages/release_github_certificate.adoc[GitHub Certificate Checks] as
 an example.
 
 As with the previous level, it is also possible to use an <<Alternative Rekor>> instance during

--- a/internal/opa/rule/rule.go
+++ b/internal/opa/rule/rule.go
@@ -34,7 +34,7 @@ func title(a *ast.AnnotationsRef) string {
 }
 
 // xrefRegExp is used to detect asciidoc links in a string.
-var xrefRegExp = regexp.MustCompile(`xref:(?:([^:]+):ROOT:(.+?)\.adoc#([^[]+)|[\w\.\$\#]+)\[([\w\s/\.]+)\]`)
+var xrefRegExp = regexp.MustCompile(`xref:(?:([^:]+):ROOT:(.+?)\.adoc(#[^[]+)?|[\w\.\$\#/]+)\[([\w\s/\.]+)\]`)
 
 func description(a *ast.AnnotationsRef) string {
 	if a == nil || a.Annotations == nil {
@@ -82,7 +82,7 @@ func replaceXrefReferencesWithURL(input string) string {
 		group := matches[1]
 		filename := matches[2]
 		anchor := matches[3]
-		return "https://conforma.dev/docs/" + group + "/" + filename + ".html#" + anchor
+		return "https://conforma.dev/docs/" + group + "/" + filename + ".html" + anchor
 	})
 }
 

--- a/internal/opa/rule/rule_test.go
+++ b/internal/opa/rule/rule_test.go
@@ -136,7 +136,7 @@ func TestDescription(t *testing.T) {
 				import rego.v1
 				# METADATA
 				# description: >-
-				#   See xref:release_policy.adoc#attestation_task_bundle_package[here] and
+				#   See xref:packages/release_attestation_type.adoc[here] and
 				#   xref:attachment$trusted_tekton_tasks.yml[over there] for details.
 				deny if { true }`)),
 			expected: "See here and over there for details.",
@@ -358,7 +358,7 @@ func TestSolution(t *testing.T) {
 				# METADATA
 				# custom:
 				#  solution: >-
-				#    See xref:release_policy.adoc#attestation_task_bundle_package[here] and
+				#    See xref:packages/release_attestation_type.adoc[here] and
 				#    xref:attachment$trusted_tekton_tasks.yml[over there] for details.
 				deny if { true }`)),
 			expected: "See here and over there for details.",


### PR DESCRIPTION
The attestation_task_bundle package was removed from conforma/policy repo.
For consistency, update references to the deprecated package with a reference to an existing package.

Also updated policy package doc links to point to their new location in the docs.

Ref: https://issues.redhat.com/browse/EC-1399