### PR TITLE
fix: increase unit test timeout to 10s in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ TEST_OUTPUT_FILTER=grep -vE '0.0% of statements|\[no test files\]'
 .PHONY: test
 test: ## Run all unit tests
 	@echo "Unit tests:"
-	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 1s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
+	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 10s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
 	@echo "Integration tests:"
 	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | $(TEST_OUTPUT_FILTER)
 # Given the nature of generative tests the test timeout is increased from 500ms

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ TEST_OUTPUT_FILTER=grep -vE '0.0% of statements|\[no test files\]'
 .PHONY: test
 test: ## Run all unit tests
 	@echo "Unit tests:"
+    # The timeout here was previously 1 second, but we've made it longer because we were seeing timeouts when testing with Sealights
 	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-unit.out -timeout 10s -tags=unit ./... | $(TEST_OUTPUT_FILTER)
 	@echo "Integration tests:"
 	@set -o pipefail && go test -race -covermode=atomic -coverprofile=coverage-integration.out -timeout 15s -tags=integration ./... | $(TEST_OUTPUT_FILTER)


### PR DESCRIPTION
Fixes Sealights unit test failures by providing 10s for test execution.

Ref: https://issues.redhat.com/browse/EC-1444