### PR TITLE
Fix untrusted rpms-signature-scan task violation

### DIFF
--- a/policies/cli/policy.yaml
+++ b/policies/cli/policy.yaml
@@ -29,6 +29,8 @@ sources:
     data:
       - github.com/release-engineering/rhtap-ec-policy//data
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      # This is likely to be retired soon, but we need it now I think
+      - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
     policy:
       # Let's not pin the digest here
       - oci::quay.io/enterprise-contract/ec-release-policy:latest


### PR DESCRIPTION
In commit ec1ade4a4f02a8cf812e245287e39d6f6cee27e6 we added a task ref from the non-standard location, which caused a violation in our tenant release pipeline.

This should fix it.

In the long term I think all the tasks are going back to the main tekton-catalog, but in the short term, this is needed so Conforma considers the task trusted.