### PR TITLE
fix: prevent concurrent map writes in imageIndexWorker

### DIFF
--- a/internal/applicationsnapshot/expansion_info.go
+++ b/internal/applicationsnapshot/expansion_info.go
@@ -16,22 +16,87 @@
 
 package applicationsnapshot
 
+import "sync"
+
 // ExpansionInfo tracks the relationships between image indexes and their child manifests
 // that are created when expanding multi-arch images.
 type ExpansionInfo struct {
-	// ChildrenByIndex maps an image index digest to the list of child manifest digests
-	ChildrenByIndex map[string][]string `json:"childrenByIndex,omitempty"`
-	// ParentByChild maps a child manifest digest to its parent index digest
-	ParentByChild map[string]string `json:"parentByChild,omitempty"`
-	// IndexAliases maps image references to their pinned digest form
-	IndexAliases map[string]string `json:"indexAliases,omitempty"`
+	// childrenByIndex maps an image index digest to the list of child manifest digests
+	childrenByIndex map[string][]string
+	// parentByChild maps a child manifest digest to its parent index digest
+	parentByChild map[string]string
+	// indexAliases maps image references to their pinned digest form
+	indexAliases map[string]string
+	// mu protects concurrent access to the maps
+	mu sync.RWMutex
 }
 
 // NewExpansionInfo creates a new ExpansionInfo instance
 func NewExpansionInfo() *ExpansionInfo {
 	return &ExpansionInfo{
-		ChildrenByIndex: make(map[string][]string),
-		ParentByChild:   make(map[string]string),
-		IndexAliases:    make(map[string]string),
+		childrenByIndex: make(map[string][]string),
+		parentByChild:   make(map[string]string),
+		indexAliases:    make(map[string]string),
 	}
+}
+
+// SetIndexAlias safely sets an index alias
+func (e *ExpansionInfo) SetIndexAlias(key, value string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.indexAliases[key] = value
+}
+
+// AddChildToIndex safely adds a child to the index
+func (e *ExpansionInfo) AddChildToIndex(index, child string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.childrenByIndex[index] = append(e.childrenByIndex[index], child)
+}
+
+// SetParentByChild safely sets the parent for a child
+func (e *ExpansionInfo) SetParentByChild(child, parent string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.parentByChild[child] = parent
+}
+
+// GetIndexAlias safely gets an index alias
+func (e *ExpansionInfo) GetIndexAlias(key string) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	value, ok := e.indexAliases[key]
+	return value, ok
+}
+
+// GetChildrenByIndex safely gets children for an index
+// Caller gets own slice to avoid race conditions
+// Example:
+//
+//	go func() {
+//	    e.AddChildToIndex("index1", "child3") // holds lock while writing
+//	}()
+//
+// children, _ := e.GetChildrenByIndex("index1") // holds lock while reading
+// children = append(children, "child4")        // modifies underlying slice WITHOUT lock
+func (e *ExpansionInfo) GetChildrenByIndex(index string) ([]string, bool) {
+	e.mu.RLock()
+	children, ok := e.childrenByIndex[index]
+	if !ok {
+		e.mu.RUnlock()
+		return nil, false
+	}
+	// Copy so caller gets their own slice
+	copyChildren := make([]string, len(children))
+	copy(copyChildren, children)
+	e.mu.RUnlock()
+	return copyChildren, true
+}
+
+// GetParentByChild safely gets the parent for a child
+func (e *ExpansionInfo) GetParentByChild(child string) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	parent, ok := e.parentByChild[child]
+	return parent, ok
 }

--- a/internal/applicationsnapshot/input.go
+++ b/internal/applicationsnapshot/input.go
@@ -235,7 +235,7 @@ func imageIndexWorker(client oci.Client, component app.SnapshotComponent, compon
 
 	// Track expansion metadata
 	idxPinned := fmt.Sprintf("%s@%s", ref.Context().Name(), desc.Digest)
-	exp.IndexAliases[ref.Name()] = idxPinned
+	exp.SetIndexAlias(ref.Name(), idxPinned)
 
 	// Add the platform-specific image references (Image Manifests) to the list of components so
 	// each is validated as well as the multi-platform image reference (Image Index).
@@ -253,8 +253,8 @@ func imageIndexWorker(client oci.Client, component app.SnapshotComponent, compon
 
 		// Track parent-child relationships
 		childPinned := archComponent.ContainerImage
-		exp.ChildrenByIndex[idxPinned] = append(exp.ChildrenByIndex[idxPinned], childPinned)
-		exp.ParentByChild[childPinned] = idxPinned
+		exp.AddChildToIndex(idxPinned, childPinned)
+		exp.SetParentByChild(childPinned, idxPinned)
 	}
 }
 

--- a/internal/validate/vsa/vsa.go
+++ b/internal/validate/vsa/vsa.go
@@ -72,7 +72,7 @@ func normalizeIndexRef(ref string, exp *applicationsnapshot.ExpansionInfo) strin
 	if exp == nil {
 		return ref
 	}
-	if pinned, ok := exp.IndexAliases[ref]; ok {
+	if pinned, ok := exp.GetIndexAlias(ref); ok {
 		return pinned
 	}
 	return ref
@@ -94,7 +94,7 @@ func FilterReportForTargetRef(report applicationsnapshot.Report, targetRef strin
 
 	include := map[string]struct{}{}
 	if exp != nil {
-		if imgs, ok := exp.ChildrenByIndex[targetRef]; ok {
+		if imgs, ok := exp.GetChildrenByIndex(targetRef); ok {
 			// This is an image index, include the index and all its children
 			include[targetRef] = struct{}{}
 			for _, c := range imgs {

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -358,17 +358,13 @@ func TestFilterReportForTargetRef(t *testing.T) {
 				{SnapshotComponent: appapi.SnapshotComponent{Name: "Unnamed-sha256:def456-arm64", ContainerImage: "quay.io/test/image@sha256:def456"}},
 				{SnapshotComponent: appapi.SnapshotComponent{Name: "OtherComponent", ContainerImage: "quay.io/other/image@sha256:other123"}},
 			},
-			expansion: &applicationsnapshot.ExpansionInfo{
-				ChildrenByIndex: map[string][]string{
-					"quay.io/test/image@sha256:index123": {
-						"quay.io/test/image@sha256:abc123",
-						"quay.io/test/image@sha256:def456",
-					},
-				},
-				IndexAliases: map[string]string{
-					"quay.io/test/image:latest": "quay.io/test/image@sha256:index123",
-				},
-			},
+			expansion: func() *applicationsnapshot.ExpansionInfo {
+				exp := applicationsnapshot.NewExpansionInfo()
+				exp.AddChildToIndex("quay.io/test/image@sha256:index123", "quay.io/test/image@sha256:abc123")
+				exp.AddChildToIndex("quay.io/test/image@sha256:index123", "quay.io/test/image@sha256:def456")
+				exp.SetIndexAlias("quay.io/test/image:latest", "quay.io/test/image@sha256:index123")
+				return exp
+			}(),
 			expectedCount:  3,
 			expectedImages: []string{"quay.io/test/image@sha256:index123", "quay.io/test/image@sha256:abc123", "quay.io/test/image@sha256:def456"},
 		},
@@ -381,14 +377,12 @@ func TestFilterReportForTargetRef(t *testing.T) {
 				{SnapshotComponent: appapi.SnapshotComponent{Name: "Unnamed-sha256:def456-arm64", ContainerImage: "quay.io/test/image@sha256:def456"}},
 				{SnapshotComponent: appapi.SnapshotComponent{Name: "OtherComponent", ContainerImage: "quay.io/other/image@sha256:other123"}},
 			},
-			expansion: &applicationsnapshot.ExpansionInfo{
-				ChildrenByIndex: map[string][]string{
-					"quay.io/test/image@sha256:index123": {
-						"quay.io/test/image@sha256:abc123",
-						"quay.io/test/image@sha256:def456",
-					},
-				},
-			},
+			expansion: func() *applicationsnapshot.ExpansionInfo {
+				exp := applicationsnapshot.NewExpansionInfo()
+				exp.AddChildToIndex("quay.io/test/image@sha256:index123", "quay.io/test/image@sha256:abc123")
+				exp.AddChildToIndex("quay.io/test/image@sha256:index123", "quay.io/test/image@sha256:def456")
+				return exp
+			}(),
 			expectedCount:  1,
 			expectedImages: []string{"quay.io/test/image@sha256:abc123"},
 		},


### PR DESCRIPTION
Add mutex synchronization to ExpansionInfo struct to protect concurrent access to IndexAliases, ChildrenByIndex, and ParentByChild maps from multiple goroutines in imageIndexWorker function.

Fixes "fatal error: concurrent map writes" runtime error.

Assited by: claude-4-sonnet

https://issues.redhat.com/browse/EC-1482