### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cli-v07

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -49,7 +49,8 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL \
-  name="ec" \
+  name="rhtas/ec-rhel9" \
+  cpe="cpe:/a:redhat:trusted_artifact_signer:1.0::el9" \
   description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   summary="Provides the binaries for downloading the Conforma CLI. Also used as a runner image for Tekton tasks." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
