### PR TITLE
feat(vsa): introduce stable VSA schema and switch to minimal payload

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -69,6 +69,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		outputFile                  string
 		policy                      policy.Policy
 		policyConfiguration         string
+		policySource                string
 		publicKey                   string
 		rekorURL                    string
 		snapshot                    string
@@ -220,6 +221,9 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				data.spec = s
 				data.expansion = exp
 			}
+
+			// Store policy source before resolution
+			data.policySource = data.policyConfiguration
 
 			policyConfiguration, err := validate_utils.GetPolicyConfig(ctx, data.policyConfiguration)
 			if err != nil {
@@ -500,7 +504,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 				}
 
 				// Create VSA service
-				vsaService := vsa.NewServiceWithFS(signer, utils.FS(cmd.Context()))
+				vsaService := vsa.NewServiceWithFS(signer, utils.FS(cmd.Context()), data.policySource, data.policy)
 
 				// Define helper functions for getting git URL and digest
 				getGitURL := func(comp applicationsnapshot.Component) string {

--- a/internal/applicationsnapshot/report.go
+++ b/internal/applicationsnapshot/report.go
@@ -224,7 +224,7 @@ func (r *Report) toFormat(format string) (data []byte, err error) {
 }
 
 func (r *Report) toVSA() ([]byte, error) {
-	generator := NewSnapshotVSAGenerator(*r)
+	generator := NewSnapshotPredicateGenerator(*r)
 	predicate, err := generator.GeneratePredicate(context.Background())
 	if err != nil {
 		return []byte{}, err

--- a/internal/applicationsnapshot/vsa_test.go
+++ b/internal/applicationsnapshot/vsa_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,15 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build unit
-
 package applicationsnapshot
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
+	"time"
 
 	ecc "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	app "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -32,60 +29,363 @@ import (
 	"github.com/conforma/cli/internal/evaluator"
 )
 
-func TestSnapshotVSAGenerator_GeneratePredicate(t *testing.T) {
+func TestGenerateSnapshotPredicate(t *testing.T) {
 	ctx := context.Background()
 
-	// Create a test report
-	report := Report{
-		Components: []Component{
-			{
-				SnapshotComponent: app.SnapshotComponent{
-					Name:           "test-component",
-					ContainerImage: "test-image:latest",
-				},
-				Success:    true,
-				Violations: []evaluator.Result{},
-				Warnings:   []evaluator.Result{},
-				Successes:  []evaluator.Result{},
+	// Create test components
+	components := []Component{
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "component-1",
+				ContainerImage: "quay.io/test/component1@sha256:abc123",
+				Source:         app.ComponentSource{},
+			},
+			Success: true,
+			Violations: []evaluator.Result{
+				{Message: "minor violation"},
+			},
+			Warnings: []evaluator.Result{
+				{Message: "warning"},
+			},
+			Successes: []evaluator.Result{
+				{Message: "success 1"},
+				{Message: "success 2"},
 			},
 		},
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "component-2",
+				ContainerImage: "quay.io/test/component2@sha256:def456",
+				Source:         app.ComponentSource{},
+			},
+			Success: false,
+			Violations: []evaluator.Result{
+				{Message: "critical violation"},
+			},
+			Warnings:  []evaluator.Result{},
+			Successes: []evaluator.Result{},
+		},
+	}
+
+	// Create test report
+	report := Report{
+		Success:    false, // Overall failure due to component-2
+		Snapshot:   "test-snapshot-123",
+		Components: components,
+		Key:        "test-key",
+		Policy: ecc.EnterpriseContractPolicySpec{
+			Name: "test-policy",
+			Sources: []ecc.Source{
+				{
+					Name: "test-source",
+					Policy: []string{
+						"https://github.com/enterprise-contract/ec-policies//policy/lib?ref=main",
+					},
+				},
+			},
+		},
+		EcVersion:     "1.2.0",
+		EffectiveTime: time.Now(),
+	}
+
+	// Create generator
+	generator := NewSnapshotPredicateGenerator(report)
+
+	// Generate Predicate
+	predicate, err := generator.GeneratePredicate(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, predicate)
+
+	// Verify Predicate structure
+	assert.Equal(t, "failed", predicate.Status)
+	assert.Equal(t, "conforma", predicate.Verifier)
+	assert.Equal(t, "test-policy", predicate.Policy.Name)
+	assert.NotEmpty(t, predicate.Timestamp)
+
+	// Verify image references
+	assert.Contains(t, predicate.ImageRefs, "quay.io/test/component1@sha256:abc123")
+	assert.Contains(t, predicate.ImageRefs, "quay.io/test/component2@sha256:def456")
+
+	// Verify summary
+	require.NotNil(t, predicate.Summary)
+	assert.Equal(t, "test-snapshot-123", predicate.Summary.Snapshot)
+	assert.Equal(t, 2, predicate.Summary.Components)
+	assert.Equal(t, false, predicate.Summary.Success)
+	assert.Equal(t, "test-key", predicate.Summary.Key)
+	assert.Equal(t, "1.2.0", predicate.Summary.EcVersion)
+
+	// Verify component details
+	componentDetails := predicate.Summary.ComponentDetails
+	assert.Len(t, componentDetails, 2)
+
+	// Check first component details
+	comp1 := componentDetails[0]
+	assert.Equal(t, "component-1", comp1.Name)
+	assert.Equal(t, "quay.io/test/component1@sha256:abc123", comp1.ContainerImage)
+	assert.Equal(t, true, comp1.Success)
+	assert.Equal(t, 1, comp1.Violations)
+	assert.Equal(t, 1, comp1.Warnings)
+	assert.Equal(t, 2, comp1.Successes)
+
+	// Check second component details
+	comp2 := componentDetails[1]
+	assert.Equal(t, "component-2", comp2.Name)
+	assert.Equal(t, "quay.io/test/component2@sha256:def456", comp2.ContainerImage)
+	assert.Equal(t, false, comp2.Success)
+	assert.Equal(t, 1, comp2.Violations)
+	assert.Equal(t, 0, comp2.Warnings)
+	assert.Equal(t, 0, comp2.Successes)
+}
+
+func TestGenerateSnapshotPredicateWithExpansion(t *testing.T) {
+	ctx := context.Background()
+
+	// Create expansion info
+	expansion := NewExpansionInfo()
+	expansion.SetIndexAlias("quay.io/test/multiarch:latest", "quay.io/test/multiarch@sha256:index123")
+	expansion.AddChildToIndex("quay.io/test/multiarch@sha256:index123", "quay.io/test/multiarch@sha256:amd64")
+	expansion.AddChildToIndex("quay.io/test/multiarch@sha256:index123", "quay.io/test/multiarch@sha256:arm64")
+
+	// Create test components with multi-arch image
+	components := []Component{
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "multiarch-component",
+				ContainerImage: "quay.io/test/multiarch:latest",
+				Source:         app.ComponentSource{},
+			},
+			Success: true,
+		},
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "simple-component",
+				ContainerImage: "quay.io/test/simple@sha256:abc123",
+				Source:         app.ComponentSource{},
+			},
+			Success: true,
+		},
+	}
+
+	// Create test report with expansion info
+	report := Report{
+		Success:    true,
+		Snapshot:   "multiarch-snapshot",
+		Components: components,
+		Key:        "multiarch-key",
+		Policy: ecc.EnterpriseContractPolicySpec{
+			Name: "multiarch-policy",
+		},
+		Expansion: expansion,
+	}
+
+	// Create generator
+	generator := NewSnapshotPredicateGenerator(report)
+
+	// Generate Predicate
+	predicate, err := generator.GeneratePredicate(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, predicate)
+
+	// Verify image references include all images
+	expectedRefs := []string{
+		"quay.io/test/multiarch:latest",
+		"quay.io/test/multiarch@sha256:index123",
+		"quay.io/test/multiarch@sha256:amd64",
+		"quay.io/test/multiarch@sha256:arm64",
+		"quay.io/test/simple@sha256:abc123",
+	}
+
+	for _, expectedRef := range expectedRefs {
+		assert.Contains(t, predicate.ImageRefs, expectedRef)
+	}
+
+	// Should not have duplicates
+	assert.Equal(t, len(expectedRefs), len(predicate.ImageRefs))
+}
+
+func TestGenerateSnapshotPredicateSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test components that all pass
+	components := []Component{
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "success-component-1",
+				ContainerImage: "quay.io/test/success1@sha256:abc123",
+				Source:         app.ComponentSource{},
+			},
+			Success:    true,
+			Violations: []evaluator.Result{},
+			Warnings:   []evaluator.Result{},
+			Successes: []evaluator.Result{
+				{Message: "all checks passed"},
+			},
+		},
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "success-component-2",
+				ContainerImage: "quay.io/test/success2@sha256:def456",
+				Source:         app.ComponentSource{},
+			},
+			Success:    true,
+			Violations: []evaluator.Result{},
+			Warnings:   []evaluator.Result{},
+			Successes: []evaluator.Result{
+				{Message: "all checks passed"},
+			},
+		},
+	}
+
+	// Create test report
+	report := Report{
+		Success:    true,
+		Snapshot:   "success-snapshot",
+		Components: components,
+		Key:        "success-key",
+		Policy: ecc.EnterpriseContractPolicySpec{
+			Name: "success-policy",
+		},
+		EcVersion:     "2.0.0",
+		EffectiveTime: time.Now(),
+	}
+
+	// Create generator
+	generator := NewSnapshotPredicateGenerator(report)
+
+	// Generate Predicate
+	predicate, err := generator.GeneratePredicate(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, predicate)
+
+	// Verify Predicate structure for success case
+	assert.Equal(t, "passed", predicate.Status)
+	assert.Equal(t, "conforma", predicate.Verifier)
+	assert.Equal(t, "success-policy", predicate.Policy.Name)
+	assert.Equal(t, "success-snapshot", predicate.Summary.Snapshot)
+	assert.Equal(t, 2, predicate.Summary.Components)
+	assert.Equal(t, true, predicate.Summary.Success)
+	assert.Equal(t, "success-key", predicate.Summary.Key)
+	assert.Equal(t, "2.0.0", predicate.Summary.EcVersion)
+}
+
+func TestWriteSnapshotPredicate(t *testing.T) {
+	// Create a test SnapshotPredicate
+	predicate := &SnapshotPredicate{
 		Policy: ecc.EnterpriseContractPolicySpec{
 			Name: "test-policy",
 		},
+		ImageRefs: []string{
+			"quay.io/test/component1@sha256:abc123",
+			"quay.io/test/component2@sha256:def456",
+		},
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Status:    "passed",
+		Summary: SnapshotSummary{
+			Snapshot:   "test-snapshot",
+			Components: 2,
+			Success:    true,
+		},
 	}
 
-	generator := NewSnapshotVSAGenerator(report)
+	// Create writer
+	writer := NewSnapshotPredicateWriter()
 
-	predicate, err := generator.GeneratePredicate(ctx)
+	// Write Predicate
+	path, err := writer.WritePredicate(predicate)
 	require.NoError(t, err)
-
-	// Verify the predicate is the same as the report
-	assert.Equal(t, report, predicate)
+	require.NotEmpty(t, path)
+	assert.Contains(t, path, "application-snapshot-vsa.json")
 }
 
-func TestSnapshotVSAWriter_WritePredicate(t *testing.T) {
-	// Create a test report
-	report := Report{
-		Components: []Component{
-			{
-				SnapshotComponent: app.SnapshotComponent{
-					Name:           "test-component",
-					ContainerImage: "test-image:latest",
-				},
-				Success: true,
+func TestGetAllImageRefsSnapshot(t *testing.T) {
+	// Create expansion info
+	expansion := NewExpansionInfo()
+	expansion.SetIndexAlias("quay.io/test/multiarch:latest", "quay.io/test/multiarch@sha256:index123")
+	expansion.AddChildToIndex("quay.io/test/multiarch@sha256:index123", "quay.io/test/multiarch@sha256:amd64")
+	expansion.AddChildToIndex("quay.io/test/multiarch@sha256:index123", "quay.io/test/multiarch@sha256:arm64")
+
+	// Create test components
+	components := []Component{
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "multiarch-component",
+				ContainerImage: "quay.io/test/multiarch:latest",
+				Source:         app.ComponentSource{},
+			},
+		},
+		{
+			SnapshotComponent: app.SnapshotComponent{
+				Name:           "simple-component",
+				ContainerImage: "quay.io/test/simple@sha256:abc123",
+				Source:         app.ComponentSource{},
 			},
 		},
 	}
 
-	writer := NewSnapshotVSAWriter()
+	// Create test report
+	report := Report{
+		Components: components,
+		Expansion:  expansion,
+	}
 
-	path, err := writer.WritePredicate(report)
-	require.NoError(t, err)
+	// Create generator
+	generator := NewSnapshotPredicateGenerator(report)
 
-	// Verify the file was created and contains valid JSON
-	assert.Contains(t, path, "snapshot-vsa-")
-	assert.Contains(t, path, "application-snapshot-vsa.json")
+	// Test getAllImageRefs method
+	imageRefs := generator.getAllImageRefs()
 
-	// Clean up
-	os.RemoveAll(filepath.Dir(path))
+	// Should contain all image references
+	expectedRefs := []string{
+		"quay.io/test/multiarch:latest",
+		"quay.io/test/multiarch@sha256:index123",
+		"quay.io/test/multiarch@sha256:amd64",
+		"quay.io/test/multiarch@sha256:arm64",
+		"quay.io/test/simple@sha256:abc123",
+	}
+
+	for _, expectedRef := range expectedRefs {
+		assert.Contains(t, imageRefs, expectedRef)
+	}
+
+	// Should not have duplicates
+	assert.Equal(t, len(expectedRefs), len(imageRefs))
+}
+
+func TestNormalizeIndexRef(t *testing.T) {
+	// Create expansion info
+	expansion := NewExpansionInfo()
+	expansion.SetIndexAlias("quay.io/test/image:latest", "quay.io/test/image@sha256:index123")
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "normalized reference",
+			ref:      "quay.io/test/image:latest",
+			expected: "quay.io/test/image@sha256:index123",
+		},
+		{
+			name:     "non-index reference",
+			ref:      "quay.io/test/simple@sha256:abc123",
+			expected: "quay.io/test/simple@sha256:abc123",
+		},
+		{
+			name:     "nil expansion",
+			ref:      "quay.io/test/image:latest",
+			expected: "quay.io/test/image:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var exp *ExpansionInfo
+			if tt.name != "nil expansion" {
+				exp = expansion
+			}
+			result := normalizeIndexRef(tt.ref, exp)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/validate/vsa/orchestrator.go
+++ b/internal/validate/vsa/orchestrator.go
@@ -19,10 +19,25 @@ package vsa
 import (
 	"context"
 	"fmt"
+
+	"github.com/conforma/cli/internal/applicationsnapshot"
 )
 
-// GenerateAndWriteVSA generates a VSA predicate and writes it to a file, returning the written path.
-func GenerateAndWriteVSA[T any](ctx context.Context, generator PredicateGenerator[T], writer PredicateWriter[T]) (string, error) {
+// GenerateAndWritePredicate generates a Predicate and writes it to a file, returning the written path.
+func GenerateAndWritePredicate(ctx context.Context, generator *Generator, writer *Writer) (string, error) {
+	pred, err := generator.GeneratePredicate(ctx)
+	if err != nil {
+		return "", err
+	}
+	writtenPath, err := writer.WritePredicate(pred)
+	if err != nil {
+		return "", err
+	}
+	return writtenPath, nil
+}
+
+// GenerateAndWriteSnapshotPredicate generates a snapshot Predicate and writes it to a file, returning the written path.
+func GenerateAndWriteSnapshotPredicate(ctx context.Context, generator *applicationsnapshot.SnapshotPredicateGenerator, writer *applicationsnapshot.SnapshotPredicateWriter) (string, error) {
 	pred, err := generator.GeneratePredicate(ctx)
 	if err != nil {
 		return "", err

--- a/internal/validate/vsa/service.go
+++ b/internal/validate/vsa/service.go
@@ -19,6 +19,7 @@ package vsa
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -34,82 +35,96 @@ type VSAProcessingResult struct {
 
 // Service encapsulates all VSA processing logic for both components and snapshots
 type Service struct {
-	signer *Signer
-	fs     afero.Fs
+	signer       *Signer
+	fs           afero.Fs
+	policySource string
+	policy       PublicKeyProvider
 }
 
 // NewServiceWithFS creates a new VSA service with the given signer and filesystem
-func NewServiceWithFS(signer *Signer, fs afero.Fs) *Service {
+func NewServiceWithFS(signer *Signer, fs afero.Fs, policySource string, policy PublicKeyProvider) *Service {
 	return &Service{
-		signer: signer,
-		fs:     fs,
+		signer:       signer,
+		fs:           fs,
+		policySource: policySource,
+		policy:       policy,
 	}
 }
 
 // ProcessComponentVSA processes VSA generation, writing, and attestation for a single component
 func (s *Service) ProcessComponentVSA(ctx context.Context, report applicationsnapshot.Report, comp applicationsnapshot.Component, gitURL, digest string) (string, error) {
-	generator := NewGenerator(report, comp)
+	generator := NewGenerator(report, comp, s.policySource, s.policy)
 	writer := &Writer{
 		FS:            s.fs,
 		TempDirPrefix: "vsa-",
 		FilePerm:      0o600,
 	}
 
-	// Generate and write VSA predicate
-	writtenPath, err := GenerateAndWriteVSA(ctx, generator, writer)
+	// Generate and write Predicate (new format)
+	writtenPath, err := GenerateAndWritePredicate(ctx, generator, writer)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate and write component VSA: %w", err)
+		return "", fmt.Errorf("failed to generate and write component Predicate: %w", err)
 	}
 
-	// Create attestor and attest VSA
-	attestor, err := NewAttestor(writtenPath, gitURL, digest, s.signer)
+	// Create attestor and attest Predicate
+	// Use the image reference (without digest) as the repo for the subject name
+	imageRef := comp.ContainerImage
+	if idx := strings.LastIndex(imageRef, "@"); idx != -1 {
+		imageRef = imageRef[:idx] // Remove digest to get just the image reference
+	}
+	attestor, err := NewAttestor(writtenPath, imageRef, digest, s.signer)
 	if err != nil {
 		return "", fmt.Errorf("failed to create component attestor: %w", err)
 	}
 
 	envelopePath, err := AttestVSA(ctx, attestor)
 	if err != nil {
-		return "", fmt.Errorf("failed to attest component VSA: %w", err)
+		return "", fmt.Errorf("failed to attest component Predicate: %w", err)
 	}
 
 	log.WithFields(log.Fields{
 		"envelope_path": envelopePath,
-	}).Info("[VSA] Component VSA attested and envelope written")
+	}).Info("[VSA] Component Predicate attested and envelope written")
 	return envelopePath, nil
 }
 
 // ProcessSnapshotVSA processes VSA generation, writing, and attestation for the application snapshot
 func (s *Service) ProcessSnapshotVSA(ctx context.Context, report applicationsnapshot.Report) (string, error) {
-	generator := applicationsnapshot.NewSnapshotVSAGenerator(report)
-	writer := applicationsnapshot.NewSnapshotVSAWriter()
+	generator := applicationsnapshot.NewSnapshotPredicateGenerator(report)
+	writer := applicationsnapshot.NewSnapshotPredicateWriter()
 	writer.FS = s.fs
 
-	// Generate and write VSA predicate
-	writtenPath, err := GenerateAndWriteVSA(ctx, generator, writer)
+	// Generate and write Predicate (new format)
+	writtenPath, err := GenerateAndWriteSnapshotPredicate(ctx, generator, writer)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate and write snapshot VSA: %w", err)
+		return "", fmt.Errorf("failed to generate and write snapshot Predicate: %w", err)
 	}
 
-	// Calculate digest for the snapshot VSA predicate
+	// Calculate digest for the snapshot Predicate
 	digest, err := applicationsnapshot.GetVSAPredicateDigest(s.fs, writtenPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to calculate digest for snapshot VSA: %w", err)
+		return "", fmt.Errorf("failed to calculate digest for snapshot Predicate: %w", err)
 	}
 
-	// Create attestor and attest VSA
-	attestor, err := NewAttestor(writtenPath, "", digest, s.signer)
+	// Create attestor and attest Predicate
+	// Use a meaningful name for the snapshot subject
+	snapshotName := "application-snapshot"
+	if report.Snapshot != "" {
+		snapshotName = report.Snapshot
+	}
+	attestor, err := NewAttestor(writtenPath, snapshotName, digest, s.signer)
 	if err != nil {
 		return "", fmt.Errorf("failed to create snapshot attestor: %w", err)
 	}
 
 	envelopePath, err := AttestVSA(ctx, attestor)
 	if err != nil {
-		return "", fmt.Errorf("failed to attest snapshot VSA: %w", err)
+		return "", fmt.Errorf("failed to attest snapshot Predicate: %w", err)
 	}
 
 	log.WithFields(log.Fields{
 		"envelope_path": envelopePath,
-	}).Info("[VSA] Snapshot VSA attested and envelope written")
+	}).Info("[VSA] Snapshot Predicate attested and envelope written")
 	return envelopePath, nil
 }
 

--- a/internal/validate/vsa/service_test.go
+++ b/internal/validate/vsa/service_test.go
@@ -107,7 +107,7 @@ func TestNewServiceWithFS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service := NewServiceWithFS(tt.signer, tt.fs)
+			service := NewServiceWithFS(tt.signer, tt.fs, "https://github.com/test/policy", nil)
 
 			if tt.expectNonNil {
 				assert.NotNil(t, service, "NewServiceWithFS should return non-nil service")
@@ -164,7 +164,7 @@ func TestService_ProcessComponentVSA(t *testing.T) {
 
 	// Create test signer
 	signer := testSigner("/test.key", fs)
-	service := NewServiceWithFS(signer, fs)
+	service := NewServiceWithFS(signer, fs, "https://github.com/test/policy", nil)
 
 	// Test successful processing
 	envelopePath, err := service.ProcessComponentVSA(ctx, report, comp, "https://github.com/test/repo", "sha256:testdigest")
@@ -195,7 +195,7 @@ func TestService_ProcessSnapshotVSA(t *testing.T) {
 
 	// Create test signer
 	signer := testSigner("/test.key", fs)
-	service := NewServiceWithFS(signer, fs)
+	service := NewServiceWithFS(signer, fs, "https://github.com/test/policy", nil)
 
 	// Test successful processing
 	envelopePath, err := service.ProcessSnapshotVSA(ctx, report)
@@ -233,7 +233,7 @@ func TestService_ProcessAllVSAs(t *testing.T) {
 
 	// Create test signer
 	signer := testSigner("/test.key", fs)
-	service := NewServiceWithFS(signer, fs)
+	service := NewServiceWithFS(signer, fs, "https://github.com/test/policy", nil)
 
 	// Define helper functions
 	getGitURL := func(comp applicationsnapshot.Component) string {
@@ -292,7 +292,7 @@ func TestService_ProcessAllVSAs_WithErrors(t *testing.T) {
 
 	// Create test signer
 	signer := testSigner("/test.key", fs)
-	service := NewServiceWithFS(signer, fs)
+	service := NewServiceWithFS(signer, fs, "https://github.com/test/policy", nil)
 
 	// Define helper functions that return errors
 	getGitURL := func(comp applicationsnapshot.Component) string {
@@ -348,7 +348,7 @@ func TestService_ProcessAllVSAs_PartialSuccess(t *testing.T) {
 
 	// Create test signer
 	signer := testSigner("/test.key", fs)
-	service := NewServiceWithFS(signer, fs)
+	service := NewServiceWithFS(signer, fs, "https://github.com/test/policy", nil)
 
 	// Define helper functions - fail for specific component
 	getGitURL := func(comp applicationsnapshot.Component) string {


### PR DESCRIPTION
Full rule results in VSAs made them large and brittle. This change introduces a compact, reproducible schema that stores only evaluation inputs and status metadata.

- Define a stable Predicate struct for VSAs capturing: resolved ECP (pinned refs), image refs, timestamp, status, verifier, and summary counts.
- Drop detailed successes/violations/warnings from the payload.
- Update VSA generation, snapshot handling, and tests to use the new predicate and write path.

Results in smaller, more stable VSA artifacts that record evaluation inputs and summary counts rather than full rule results.

https://issues.redhat.com/browse/EC-1488
https://issues.redhat.com/browse/EC-1489