### PR TITLE
Support retrieving the vsa from file system path

### DIFF
--- a/internal/validate/vsa/file_retriever.go
+++ b/internal/validate/vsa/file_retriever.go
@@ -1,0 +1,146 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+// FileVSARetriever implements VSARetriever using filesystem storage
+type FileVSARetriever struct {
+	fs       afero.Fs
+	basePath string
+}
+
+// NewFileVSARetriever creates a new filesystem-based VSA retriever
+func NewFileVSARetriever(fs afero.Fs, basePath string) *FileVSARetriever {
+	return &FileVSARetriever{
+		fs:       fs,
+		basePath: basePath,
+	}
+}
+
+// NewFileVSARetrieverWithOSFs creates a new filesystem-based VSA retriever using the OS filesystem
+func NewFileVSARetrieverWithOSFs(basePath string) *FileVSARetriever {
+	return &FileVSARetriever{
+		fs:       afero.NewOsFs(),
+		basePath: basePath,
+	}
+}
+
+// RetrieveVSA retrieves VSA data as a DSSE envelope from a file path
+// The identifier can be:
+// - A direct file path (e.g., "/path/to/vsa.json")
+// - A relative path that will be resolved against basePath
+// - A filename that will be looked up in basePath
+func (f *FileVSARetriever) RetrieveVSA(ctx context.Context, identifier string) (*ssldsse.Envelope, error) {
+	if identifier == "" {
+		return nil, fmt.Errorf("file path identifier cannot be empty")
+	}
+
+	// Determine the full file path
+	filePath := f.resolveFilePath(identifier)
+
+	log.Debugf("Retrieving VSA from file: %s", filePath)
+
+	// Check if file exists
+	exists, err := afero.Exists(f.fs, filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if file exists: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("VSA file not found: %s", filePath)
+	}
+
+	// Read the file
+	data, err := afero.ReadFile(f.fs, filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read VSA file: %w", err)
+	}
+
+	// Parse the DSSE envelope
+	envelope, err := f.parseDSSEEnvelope(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DSSE envelope from file: %w", err)
+	}
+
+	log.Debugf("Successfully retrieved VSA from file: %s", filePath)
+	return envelope, nil
+}
+
+// resolveFilePath determines the full file path from the identifier
+func (f *FileVSARetriever) resolveFilePath(identifier string) string {
+	// If it's an absolute path, use it directly
+	if filepath.IsAbs(identifier) {
+		return identifier
+	}
+
+	// If basePath is empty, use the identifier as-is
+	if f.basePath == "" {
+		return identifier
+	}
+
+	// Otherwise, resolve relative to basePath
+	return filepath.Join(f.basePath, identifier)
+}
+
+// parseDSSEEnvelope parses a DSSE envelope from JSON data
+func (f *FileVSARetriever) parseDSSEEnvelope(data []byte) (*ssldsse.Envelope, error) {
+	var envelope ssldsse.Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal DSSE envelope: %w", err)
+	}
+
+	// Validate the envelope has required fields
+	if envelope.PayloadType == "" {
+		return nil, fmt.Errorf("DSSE envelope missing payloadType")
+	}
+	if envelope.Payload == "" {
+		return nil, fmt.Errorf("DSSE envelope missing payload")
+	}
+	if len(envelope.Signatures) == 0 {
+		return nil, fmt.Errorf("DSSE envelope missing signatures")
+	}
+
+	return &envelope, nil
+}
+
+// FileVSARetrieverOptions configures filesystem-based VSA retrieval behavior
+type FileVSARetrieverOptions struct {
+	BasePath string
+	FS       afero.Fs
+}
+
+// NewFileVSARetrieverWithOptions creates a new filesystem-based VSA retriever with options
+func NewFileVSARetrieverWithOptions(opts FileVSARetrieverOptions) *FileVSARetriever {
+	fs := opts.FS
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
+
+	return &FileVSARetriever{
+		fs:       fs,
+		basePath: opts.BasePath,
+	}
+}

--- a/internal/validate/vsa/file_retriever_test.go
+++ b/internal/validate/vsa/file_retriever_test.go
@@ -1,0 +1,401 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileVSARetriever_RetrieveVSA(t *testing.T) {
+	// Create a test DSSE envelope
+	envelope := &ssldsse.Envelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     "eyJ0eXBlIjoiaHR0cHM6Ly9pbi10b3RvLmlvL0pzb25TZXJpYWxpemF0aW9uLzEuMC9wcmVkaWNhdGUifQ==",
+		Signatures: []ssldsse.Signature{
+			{
+				KeyID: "test-key-id",
+				Sig:   "test-signature",
+			},
+		},
+	}
+
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	fs := afero.NewMemMapFs()
+
+	// Create a test VSA file
+	vsaPath := filepath.Join(tempDir, "test-vsa.json")
+	envelopeJSON, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	// Write to both real filesystem and memory filesystem for different tests
+	err = os.WriteFile(vsaPath, envelopeJSON, 0600)
+	require.NoError(t, err)
+
+	// Also write to memory filesystem
+	err = afero.WriteFile(fs, "test-vsa.json", envelopeJSON, 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		identifier  string
+		basePath    string
+		fs          afero.Fs
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "absolute path with real filesystem",
+			identifier:  vsaPath,
+			basePath:    "",
+			fs:          afero.NewOsFs(),
+			expectError: false,
+		},
+		{
+			name:        "relative path with memory filesystem",
+			identifier:  "test-vsa.json",
+			basePath:    "",
+			fs:          fs,
+			expectError: false,
+		},
+		{
+			name:        "relative path with base path",
+			identifier:  "test-vsa.json",
+			basePath:    tempDir,
+			fs:          afero.NewOsFs(),
+			expectError: false,
+		},
+		{
+			name:        "non-existent file",
+			identifier:  "non-existent.json",
+			basePath:    "",
+			fs:          fs,
+			expectError: true,
+			errorMsg:    "VSA file not found",
+		},
+		{
+			name:        "empty identifier",
+			identifier:  "",
+			basePath:    "",
+			fs:          fs,
+			expectError: true,
+			errorMsg:    "file path identifier cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			retriever := &FileVSARetriever{
+				fs:       tt.fs,
+				basePath: tt.basePath,
+			}
+
+			result, err := retriever.RetrieveVSA(context.Background(), tt.identifier)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, envelope.PayloadType, result.PayloadType)
+				assert.Equal(t, envelope.Payload, result.Payload)
+				assert.Len(t, result.Signatures, 1)
+				assert.Equal(t, envelope.Signatures[0].KeyID, result.Signatures[0].KeyID)
+				assert.Equal(t, envelope.Signatures[0].Sig, result.Signatures[0].Sig)
+			}
+		})
+	}
+}
+
+func TestFileVSARetriever_NewFileVSARetriever(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	basePath := "/test/path"
+
+	retriever := NewFileVSARetriever(fs, basePath)
+
+	assert.Equal(t, fs, retriever.fs)
+	assert.Equal(t, basePath, retriever.basePath)
+}
+
+func TestFileVSARetriever_NewFileVSARetrieverWithOSFs(t *testing.T) {
+	basePath := "/test/path"
+
+	retriever := NewFileVSARetrieverWithOSFs(basePath)
+
+	assert.IsType(t, &afero.OsFs{}, retriever.fs)
+	assert.Equal(t, basePath, retriever.basePath)
+}
+
+func TestFileVSARetriever_NewFileVSARetrieverWithOptions(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	basePath := "/test/path"
+
+	opts := FileVSARetrieverOptions{
+		BasePath: basePath,
+		FS:       fs,
+	}
+
+	retriever := NewFileVSARetrieverWithOptions(opts)
+
+	assert.Equal(t, fs, retriever.fs)
+	assert.Equal(t, basePath, retriever.basePath)
+}
+
+func TestFileVSARetriever_NewFileVSARetrieverWithOptions_DefaultFS(t *testing.T) {
+	basePath := "/test/path"
+
+	opts := FileVSARetrieverOptions{
+		BasePath: basePath,
+		// FS is nil, should use default
+	}
+
+	retriever := NewFileVSARetrieverWithOptions(opts)
+
+	assert.IsType(t, &afero.OsFs{}, retriever.fs)
+	assert.Equal(t, basePath, retriever.basePath)
+}
+
+func TestFileVSARetriever_parseDSSEEnvelope(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	retriever := &FileVSARetriever{fs: fs}
+
+	// Test valid envelope
+	envelope := &ssldsse.Envelope{
+		PayloadType: "application/vnd.in-toto+json",
+		Payload:     "test-payload",
+		Signatures: []ssldsse.Signature{
+			{KeyID: "test-key", Sig: "test-sig"},
+		},
+	}
+
+	envelopeJSON, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	result, err := retriever.parseDSSEEnvelope(envelopeJSON)
+	require.NoError(t, err)
+	assert.Equal(t, envelope.PayloadType, result.PayloadType)
+	assert.Equal(t, envelope.Payload, result.Payload)
+	assert.Len(t, result.Signatures, 1)
+
+	// Test invalid JSON
+	_, err = retriever.parseDSSEEnvelope([]byte("invalid json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal DSSE envelope")
+
+	// Test missing payloadType
+	invalidEnvelope := map[string]interface{}{
+		"payload": "test",
+		"signatures": []map[string]interface{}{
+			{"keyid": "test", "sig": "test"},
+		},
+	}
+	invalidJSON, err := json.Marshal(invalidEnvelope)
+	require.NoError(t, err)
+
+	_, err = retriever.parseDSSEEnvelope(invalidJSON)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DSSE envelope missing payloadType")
+}
+
+func TestFileVSARetriever_resolveFilePath(t *testing.T) {
+	retriever := &FileVSARetriever{
+		fs:       afero.NewMemMapFs(),
+		basePath: "/base/path",
+	}
+
+	tests := []struct {
+		name       string
+		identifier string
+		expected   string
+	}{
+		{
+			name:       "absolute path",
+			identifier: "/absolute/path/file.json",
+			expected:   "/absolute/path/file.json",
+		},
+		{
+			name:       "relative path with base",
+			identifier: "file.json",
+			expected:   "/base/path/file.json",
+		},
+		{
+			name:       "relative path without base",
+			identifier: "file.json",
+			expected:   "/base/path/file.json",
+		},
+	}
+
+	// Test with base path
+	for _, tt := range tests {
+		t.Run(tt.name+"_with_base", func(t *testing.T) {
+			result := retriever.resolveFilePath(tt.identifier)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	// Test without base path
+	retriever.basePath = ""
+	for _, tt := range tests {
+		t.Run(tt.name+"_without_base", func(t *testing.T) {
+			result := retriever.resolveFilePath(tt.identifier)
+			if tt.identifier == "/absolute/path/file.json" {
+				assert.Equal(t, "/absolute/path/file.json", result)
+			} else {
+				assert.Equal(t, tt.identifier, result)
+			}
+		})
+	}
+}
+
+func TestFileVSARetriever_RetrieveVSA_ErrorCases(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	retriever := &FileVSARetriever{fs: fs}
+
+	// Create a test file with invalid JSON
+	invalidJSON := []byte(`{"invalid": json}`)
+	err := afero.WriteFile(fs, "invalid.json", invalidJSON, 0600)
+	require.NoError(t, err)
+
+	// Create a test file with valid JSON but invalid DSSE structure
+	invalidDSSE := map[string]interface{}{
+		"payload": "test",
+		// Missing payloadType and signatures
+	}
+	invalidDSSEJSON, err := json.Marshal(invalidDSSE)
+	require.NoError(t, err)
+	err = afero.WriteFile(fs, "invalid-dsse.json", invalidDSSEJSON, 0600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		identifier  string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "file with invalid JSON",
+			identifier:  "invalid.json",
+			expectError: true,
+			errorMsg:    "failed to unmarshal DSSE envelope",
+		},
+		{
+			name:        "file with invalid DSSE structure",
+			identifier:  "invalid-dsse.json",
+			expectError: true,
+			errorMsg:    "DSSE envelope missing payloadType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := retriever.RetrieveVSA(context.Background(), tt.identifier)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestFileVSARetriever_parseDSSEEnvelope_ErrorCases(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	retriever := &FileVSARetriever{fs: fs}
+
+	tests := []struct {
+		name        string
+		envelope    map[string]interface{}
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "missing payloadType",
+			envelope: map[string]interface{}{
+				"payload": "test",
+				"signatures": []map[string]interface{}{
+					{"keyid": "test", "sig": "test"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "DSSE envelope missing payloadType",
+		},
+		{
+			name: "missing signatures",
+			envelope: map[string]interface{}{
+				"payloadType": "application/vnd.in-toto+json",
+				"payload":     "test",
+			},
+			expectError: true,
+			errorMsg:    "DSSE envelope missing signatures",
+		},
+		{
+			name: "empty signatures array",
+			envelope: map[string]interface{}{
+				"payloadType": "application/vnd.in-toto+json",
+				"payload":     "test",
+				"signatures":  []map[string]interface{}{},
+			},
+			expectError: true,
+			errorMsg:    "DSSE envelope missing signatures",
+		},
+		{
+			name: "invalid signature structure",
+			envelope: map[string]interface{}{
+				"payloadType": "application/vnd.in-toto+json",
+				"payload":     "test",
+				"signatures": []map[string]interface{}{
+					{"invalid": "structure"},
+				},
+			},
+			expectError: false, // The function doesn't validate signature structure, only presence
+			errorMsg:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelopeJSON, err := json.Marshal(tt.envelope)
+			require.NoError(t, err)
+
+			result, err := retriever.parseDSSEEnvelope(envelopeJSON)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/internal/validate/vsa/rekor_retriever_test.go
+++ b/internal/validate/vsa/rekor_retriever_test.go
@@ -174,7 +174,7 @@ func TestRekorVSARetriever_RetrieveVSA_EmptyDigest(t *testing.T) {
 
 	_, err := retriever.RetrieveVSA(context.Background(), "")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "image digest cannot be empty")
+	assert.Contains(t, err.Error(), "identifier cannot be empty")
 }
 
 func TestRekorVSARetriever_RetrieveVSA_NoEntries(t *testing.T) {

--- a/internal/validate/vsa/retrieval.go
+++ b/internal/validate/vsa/retrieval.go
@@ -25,9 +25,10 @@ import (
 
 // VSARetriever defines the interface for retrieving VSA records from various sources
 type VSARetriever interface {
-	// RetrieveVSA retrieves VSA data as a DSSE envelope for a given image digest
-	// This is the main method used by validation functions to get VSA data for signature verification
-	RetrieveVSA(ctx context.Context, imageDigest string) (*ssldsse.Envelope, error)
+	// RetrieveVSA retrieves VSA data as a DSSE envelope for a given identifier
+	// The identifier can be a digest, image reference, file path, or any other string
+	// that the specific retriever implementation understands
+	RetrieveVSA(ctx context.Context, identifier string) (*ssldsse.Envelope, error)
 }
 
 // RetrievalOptions configures VSA retrieval behavior

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -512,14 +512,14 @@ func TestVSAChecker_CheckExistingVSA_ErrorCases(t *testing.T) {
 			imageRef:    "registry.example.com/test:latest",
 			expiration:  24 * time.Hour,
 			expectError: true,
-			errorMsg:    "failed to extract digest from image reference",
+			errorMsg:    "failed to retrieve VSA envelope",
 		},
 		{
 			name:        "empty image reference",
 			imageRef:    "",
 			expiration:  24 * time.Hour,
 			expectError: true,
-			errorMsg:    "failed to extract digest from image reference",
+			errorMsg:    "failed to retrieve VSA envelope",
 		},
 	}
 


### PR DESCRIPTION
This adds support for retrieving a vsa from a file system path. This is helpful for debugging. it also make retrieveVSA more generic by supporting an indentifier instead of an image digest.