### PR TITLE
feat: support k8s:// URLs for VSA signing keys

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -497,7 +497,8 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			}
 
 			if data.vsaEnabled {
-				signer, err := vsa.NewSigner(data.vsaSigningKey, utils.FS(cmd.Context()))
+				// Use the signer function that supports both file and k8s:// URLs
+				signer, err := vsa.NewSigner(cmd.Context(), data.vsaSigningKey, utils.FS(cmd.Context()))
 				if err != nil {
 					log.Error(err)
 					return err
@@ -669,7 +670,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 		- "ec-policy": Uses Enterprise Contract policy filtering with pipeline intention support`))
 
 	cmd.Flags().BoolVar(&data.vsaEnabled, "vsa", false, "Generate a Verification Summary Attestation (VSA) for each validated image.")
-	cmd.Flags().StringVar(&data.vsaSigningKey, "vsa-signing-key", "", "Path to the private key for signing the VSA.")
+	cmd.Flags().StringVar(&data.vsaSigningKey, "vsa-signing-key", "", "Path to the private key for signing the VSA. Supports file paths and Kubernetes secret references (k8s://namespace/secret-name/key-field).")
 	cmd.Flags().StringSliceVar(&data.vsaUpload, "vsa-upload", nil, "Storage backends for VSA upload. Format: backend@url?param=value. Examples: rekor@https://rekor.sigstore.dev, local@./vsa-dir")
 	cmd.Flags().DurationVar(&data.vsaExpiration, "vsa-expiration", data.vsaExpiration, "Expiration threshold for existing VSAs. If a valid VSA exists and is newer than this threshold, validation will be skipped. (default 168h)")
 

--- a/docs/modules/ROOT/pages/ec_validate_image.adoc
+++ b/docs/modules/ROOT/pages/ec_validate_image.adoc
@@ -154,7 +154,7 @@ JSON of the "spec" or a reference to a Kubernetes object [<namespace>/]<name>
 -s, --strict:: Return non-zero status on non-successful validation. Defaults to true. Use --strict=false to return a zero status code. (Default: true)
 --vsa:: Generate a Verification Summary Attestation (VSA) for each validated image. (Default: false)
 --vsa-expiration:: Expiration threshold for existing VSAs. If a valid VSA exists and is newer than this threshold, validation will be skipped. (default 168h) (Default: 168h0m0s)
---vsa-signing-key:: Path to the private key for signing the VSA.
+--vsa-signing-key:: Path to the private key for signing the VSA. Supports file paths and Kubernetes secret references (k8s://namespace/secret-name/key-field).
 --vsa-upload:: Storage backends for VSA upload. Format: backend@url?param=value. Examples: rekor@https://rekor.sigstore.dev, local@./vsa-dir (Default: [])
 --workers:: Number of workers to use for validation. Defaults to 5. (Default: 5)
 

--- a/internal/utils/key_resolver.go
+++ b/internal/utils/key_resolver.go
@@ -1,0 +1,153 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// contextKey is a custom type for context keys to avoid collisions
+type contextKey string
+
+const K8sClientKey contextKey = "k8s.client"
+
+// KeyFromKeyRef resolves a key from either a file path or a Kubernetes secret reference.
+// This provides a unified interface for both public and private key resolution.
+// Supported formats:
+// - File path: "/path/to/key.pem"
+// - Kubernetes secret: "k8s://namespace/secret-name/key-field" (explicit key field)
+// - Kubernetes secret: "k8s://namespace/secret-name" (auto-select if single key exists)
+func KeyFromKeyRef(ctx context.Context, keyRef string, fs afero.Fs) ([]byte, error) {
+	if strings.HasPrefix(keyRef, "k8s://") {
+		return keyFromKubernetesSecret(ctx, keyRef)
+	}
+	return keyFromFile(keyRef, fs)
+}
+
+// PublicKeyFromKeyRef resolves a public key from either a file path or a Kubernetes secret reference.
+// This provides a consistent interface with PrivateKeyFromKeyRef.
+// Supported formats:
+// - File path: "/path/to/public-key.pem"
+// - Kubernetes secret: "k8s://namespace/secret-name/key-field" (explicit key field)
+// - Kubernetes secret: "k8s://namespace/secret-name" (auto-select if single key exists)
+func PublicKeyFromKeyRef(ctx context.Context, keyRef string, fs afero.Fs) ([]byte, error) {
+	return KeyFromKeyRef(ctx, keyRef, fs)
+}
+
+// keyFromFile reads a key from the filesystem
+func keyFromFile(keyPath string, fs afero.Fs) ([]byte, error) {
+	keyBytes, err := afero.ReadFile(fs, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read key from file %q: %w", keyPath, err)
+	}
+	return keyBytes, nil
+}
+
+// keyFromKubernetesSecret reads a key from a Kubernetes secret
+// Supported formats:
+// - k8s://namespace/secret-name/key-field (explicit key field)
+// - k8s://namespace/secret-name (auto-select if single key exists)
+func keyFromKubernetesSecret(ctx context.Context, keyRef string) ([]byte, error) {
+	// Validate format first before attempting to create client
+	parts := strings.Split(strings.TrimPrefix(keyRef, "k8s://"), "/")
+	if len(parts) < 2 || len(parts) > 3 {
+		return nil, fmt.Errorf("invalid k8s key reference format %q, expected k8s://namespace/secret-name or k8s://namespace/secret-name/key-field", keyRef)
+	}
+
+	namespace := parts[0]
+	secretName := parts[1]
+	var keyField string
+	if len(parts) == 3 {
+		keyField = parts[2]
+	}
+
+	if namespace == "" || secretName == "" {
+		return nil, fmt.Errorf("invalid k8s key reference %q: namespace and secret name must be specified", keyRef)
+	}
+
+	k8sClient, err := getKubernetesClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get kubernetes client: %w", err)
+	}
+
+	secret, err := k8sClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("fetch secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	// If key field is specified, use it directly
+	if keyField != "" {
+		keyData, exists := secret.Data[keyField]
+		if !exists {
+			return nil, fmt.Errorf("key field %q not found in secret %s/%s", keyField, namespace, secretName)
+		}
+		return keyData, nil
+	}
+
+	// No key field specified - auto-select if single key exists
+	keyCount := len(secret.Data)
+	if keyCount == 0 {
+		return nil, fmt.Errorf("secret %s/%s contains no keys", namespace, secretName)
+	}
+	if keyCount == 1 {
+		// Get the single key
+		for _, keyData := range secret.Data {
+			return keyData, nil
+		}
+	}
+
+	// Multiple keys exist - return error without exposing key names
+	return nil, fmt.Errorf("secret %s/%s contains multiple keys, please specify the key field: k8s://%s/%s/<key-field>",
+		namespace, secretName, namespace, secretName)
+}
+
+// getKubernetesClient retrieves a Kubernetes client from the context or creates a new one
+func getKubernetesClient(ctx context.Context) (kubernetes.Interface, error) {
+	// Try to get from context first (for testing)
+	if client, ok := ctx.Value(K8sClientKey).(kubernetes.Interface); ok {
+		return client, nil
+	}
+
+	// Create a new client using the same pattern as the existing kubernetes package
+	// This follows the same pattern as used in the policy package
+	config, err := getKubernetesConfig()
+	if err != nil {
+		return nil, fmt.Errorf("get kubernetes config: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client: %w", err)
+	}
+
+	return client, nil
+}
+
+// getKubernetesConfig creates a Kubernetes config following the same pattern as the existing code
+func getKubernetesConfig() (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, nil)
+	return clientConfig.ClientConfig()
+}

--- a/internal/utils/private_key.go
+++ b/internal/utils/private_key.go
@@ -1,0 +1,32 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+
+	"github.com/spf13/afero"
+)
+
+// PrivateKeyFromKeyRef resolves a private key from either a file path or a Kubernetes secret reference.
+// This follows the same pattern as cosignSig.PublicKeyFromKeyRef but for private keys.
+// Supported formats:
+// - File path: "/path/to/private-key.pem"
+// - Kubernetes secret: "k8s://namespace/secret-name/key-field"
+func PrivateKeyFromKeyRef(ctx context.Context, keyRef string, fs afero.Fs) ([]byte, error) {
+	return KeyFromKeyRef(ctx, keyRef, fs)
+}

--- a/internal/utils/private_key_test.go
+++ b/internal/utils/private_key_test.go
@@ -1,0 +1,301 @@
+// Copyright The Conforma Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPrivateKeyFromKeyRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyRef    string
+		setup     func(fs afero.Fs, ctx context.Context)
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name:   "file path",
+			keyRef: "/path/to/key.pem",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				err := afero.WriteFile(fs, "/path/to/key.pem", []byte("test key content"), 0600)
+				require.NoError(t, err)
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with explicit key field",
+			keyRef: "k8s://test-namespace/test-secret/private-key",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with single key (auto-select)",
+			keyRef: "k8s://test-namespace/single-key-secret",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with multiple keys (no key field specified)",
+			keyRef: "k8s://test-namespace/multi-key-secret",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: true,
+			errMsg:    "contains multiple keys, please specify the key field",
+		},
+		{
+			name:      "invalid k8s format",
+			keyRef:    "k8s://invalid-format",
+			setup:     func(fs afero.Fs, ctx context.Context) {},
+			expectErr: true,
+			errMsg:    "invalid k8s key reference format",
+		},
+		{
+			name:      "file not found",
+			keyRef:    "/nonexistent/key.pem",
+			setup:     func(fs afero.Fs, ctx context.Context) {},
+			expectErr: true,
+			errMsg:    "read key from file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			ctx := context.Background()
+
+			// Setup Kubernetes client for k8s tests
+			if strings.HasPrefix(tt.keyRef, "k8s://") {
+				var secrets []*v1.Secret
+
+				if tt.keyRef == "k8s://test-namespace/test-secret/private-key" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"private-key": []byte("test private key content"),
+						},
+					})
+				} else if tt.keyRef == "k8s://test-namespace/single-key-secret" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "single-key-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"cosign.key": []byte("single key content"),
+						},
+					})
+				} else if tt.keyRef == "k8s://test-namespace/multi-key-secret" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "multi-key-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"key1": []byte("key1 content"),
+							"key2": []byte("key2 content"),
+						},
+					})
+				}
+
+				if len(secrets) > 0 {
+					client := fake.NewSimpleClientset()
+					for _, secret := range secrets {
+						_, err := client.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+						require.NoError(t, err)
+					}
+					ctx = context.WithValue(ctx, K8sClientKey, client)
+				}
+			}
+
+			tt.setup(fs, ctx)
+
+			keyBytes, err := PrivateKeyFromKeyRef(ctx, tt.keyRef, fs)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				assert.Nil(t, keyBytes)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, keyBytes)
+
+				// Verify expected content for specific test cases
+				if tt.keyRef == "k8s://test-namespace/single-key-secret" {
+					assert.Equal(t, []byte("single key content"), keyBytes)
+				} else if tt.keyRef == "k8s://test-namespace/test-secret/private-key" {
+					assert.Equal(t, []byte("test private key content"), keyBytes)
+				}
+			}
+		})
+	}
+}
+
+func TestPublicKeyFromKeyRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyRef    string
+		setup     func(fs afero.Fs, ctx context.Context)
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name:   "file path",
+			keyRef: "/path/to/public-key.pem",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				err := afero.WriteFile(fs, "/path/to/public-key.pem", []byte("test public key content"), 0600)
+				require.NoError(t, err)
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with explicit key field",
+			keyRef: "k8s://test-namespace/test-secret/public-key",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with single key (auto-select)",
+			keyRef: "k8s://test-namespace/single-key-secret",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: false,
+		},
+		{
+			name:   "k8s secret with multiple keys (no key field specified)",
+			keyRef: "k8s://test-namespace/multi-key-secret",
+			setup: func(fs afero.Fs, ctx context.Context) {
+				// This will be handled in the test loop
+			},
+			expectErr: true,
+			errMsg:    "contains multiple keys, please specify the key field",
+		},
+		{
+			name:      "invalid k8s format",
+			keyRef:    "k8s://invalid-format",
+			setup:     func(fs afero.Fs, ctx context.Context) {},
+			expectErr: true,
+			errMsg:    "invalid k8s key reference format",
+		},
+		{
+			name:      "file not found",
+			keyRef:    "/nonexistent/public-key.pem",
+			setup:     func(fs afero.Fs, ctx context.Context) {},
+			expectErr: true,
+			errMsg:    "read key from file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			ctx := context.Background()
+
+			// Setup Kubernetes client for k8s tests
+			if strings.HasPrefix(tt.keyRef, "k8s://") {
+				var secrets []*v1.Secret
+
+				if tt.keyRef == "k8s://test-namespace/test-secret/public-key" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"public-key": []byte("test public key content"),
+						},
+					})
+				} else if tt.keyRef == "k8s://test-namespace/single-key-secret" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "single-key-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"cosign.pub": []byte("single key content"),
+						},
+					})
+				} else if tt.keyRef == "k8s://test-namespace/multi-key-secret" {
+					secrets = append(secrets, &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "multi-key-secret",
+							Namespace: "test-namespace",
+						},
+						Data: map[string][]byte{
+							"key1": []byte("key1 content"),
+							"key2": []byte("key2 content"),
+						},
+					})
+				}
+
+				if len(secrets) > 0 {
+					client := fake.NewSimpleClientset()
+					for _, secret := range secrets {
+						_, err := client.CoreV1().Secrets(secret.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+						require.NoError(t, err)
+					}
+					ctx = context.WithValue(ctx, K8sClientKey, client)
+				}
+			}
+
+			tt.setup(fs, ctx)
+
+			result, err := PublicKeyFromKeyRef(ctx, tt.keyRef, fs)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+
+				// Verify expected content for specific test cases
+				if tt.keyRef == "k8s://test-namespace/single-key-secret" {
+					assert.Equal(t, []byte("single key content"), result)
+				} else if tt.keyRef == "k8s://test-namespace/test-secret/public-key" {
+					assert.Equal(t, []byte("test public key content"), result)
+				} else {
+					assert.NotNil(t, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/validate/vsa/vsa_test.go
+++ b/internal/validate/vsa/vsa_test.go
@@ -595,7 +595,8 @@ OURRVjNQMk9ndDFDaVFHeGg1VXhUZytGc3c9PSJ9
 	require.NoError(t, err)
 
 	t.Run("successful signer creation", func(t *testing.T) {
-		signer, err := NewSigner(keyPath, fs)
+		ctx := context.Background()
+		signer, err := NewSigner(ctx, keyPath, fs)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, signer)
@@ -606,19 +607,21 @@ OURRVjNQMk9ndDFDaVFHeGg1VXhUZytGc3c9PSJ9
 	})
 
 	t.Run("missing key file", func(t *testing.T) {
-		signer, err := NewSigner("/nonexistent.key", fs)
+		ctx := context.Background()
+		signer, err := NewSigner(ctx, "/nonexistent.key", fs)
 
 		assert.Error(t, err)
 		assert.Nil(t, signer)
-		assert.Contains(t, err.Error(), "read key")
+		assert.Contains(t, err.Error(), "resolve private key")
 	})
 
 	t.Run("invalid key content", func(t *testing.T) {
+		ctx := context.Background()
 		invalidKeyPath := "/invalid.key"
 		err := afero.WriteFile(fs, invalidKeyPath, []byte("invalid key content"), 0600)
 		require.NoError(t, err)
 
-		signer, err := NewSigner(invalidKeyPath, fs)
+		signer, err := NewSigner(ctx, invalidKeyPath, fs)
 
 		assert.Error(t, err)
 		assert.Nil(t, signer)
@@ -648,7 +651,8 @@ OURRVjNQMk9ndDFDaVFHeGg1VXhUZytGc3c9PSJ9
 	err := afero.WriteFile(fs, keyPath, []byte(testKey), 0600)
 	require.NoError(t, err)
 
-	signer, err := NewSigner(keyPath, fs)
+	ctx := context.Background()
+	signer, err := NewSigner(ctx, keyPath, fs)
 	require.NoError(t, err)
 
 	t.Run("successful attestor creation", func(t *testing.T) {


### PR DESCRIPTION
Add support for reading VSA signing keys from Kubernetes secrets using k8s://namespace/secret-name/key-field format, in addition to file paths. Consolidates key resolution logic for both public and private keys.

- Add KeyFromKeyRef utility for unified key resolution
- Support both file paths and k8s:// URLs for private keys
- Maintain backward compatibility with existing file-based keys