### PR TITLE
Include enforcement date in warnings for future effective_on violations

### DIFF
--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -357,7 +357,7 @@ Error: success criteria not met
       "source": {},
       "warnings": [
         {
-          "msg": "Fails in 2099",
+          "msg": "Fails in 2099. This will become a failure starting on ${TIMESTAMP}",
           "metadata": {
             "effective_on": "${TIMESTAMP}"
           }

--- a/internal/evaluator/conftest_evaluator_unit_core_test.go
+++ b/internal/evaluator/conftest_evaluator_unit_core_test.go
@@ -221,7 +221,7 @@ func TestConftestEvaluatorEvaluateSeverity(t *testing.T) {
 				},
 
 				{
-					Message: "not yet effective",
+					Message: "not yet effective. This will become a failure starting on 3021-01-01T00:00:00Z",
 					Metadata: map[string]any{
 						"effective_on": "3021-01-01T00:00:00Z",
 					},

--- a/internal/evaluator/filters.go
+++ b/internal/evaluator/filters.go
@@ -392,6 +392,13 @@ func extractStringArrayFromRuleData(src ecc.Source, key string) []string {
 	}
 }
 
+// formatEffectiveOnMessage returns the message with an appended notice
+// indicating when the rule will begin enforcement.
+func formatEffectiveOnMessage(message, effectiveOn string) string {
+	return fmt.Sprintf("%s. This will become a failure starting on %s",
+		strings.TrimSuffix(message, "."), effectiveOn)
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Comprehensive Policy Resolution
 //////////////////////////////////////////////////////////////////////////////
@@ -996,7 +1003,10 @@ func (f *LegacyPostEvaluationFilter) CategorizeResults(
 				warnings = append(warnings, result)
 			}
 		case "failure":
-			if getSeverity(result) == severityWarning || !isResultEffective(result, effectiveTime) {
+			if getSeverity(result) == severityWarning {
+				warnings = append(warnings, result)
+			} else if !isResultEffective(result, effectiveTime) {
+				result.Message = formatEffectiveOnMessage(result.Message, result.Metadata[metadataEffectiveOn].(string))
 				warnings = append(warnings, result)
 			} else {
 				failures = append(failures, result)
@@ -1119,7 +1129,10 @@ func (f *UnifiedPostEvaluationFilter) CategorizeResults(
 				warnings = append(warnings, filteredResult)
 			}
 		case "failure":
-			if getSeverity(filteredResult) == severityWarning || !isResultEffective(filteredResult, effectiveTime) {
+			if getSeverity(filteredResult) == severityWarning {
+				warnings = append(warnings, filteredResult)
+			} else if !isResultEffective(filteredResult, effectiveTime) {
+				filteredResult.Message = formatEffectiveOnMessage(filteredResult.Message, filteredResult.Metadata[metadataEffectiveOn].(string))
 				warnings = append(warnings, filteredResult)
 			} else {
 				failures = append(failures, filteredResult)

--- a/internal/evaluator/filters_test.go
+++ b/internal/evaluator/filters_test.go
@@ -758,6 +758,169 @@ func TestUnifiedPostEvaluationFilter(t *testing.T) {
 	})
 }
 
+func TestUnifiedCategorizeResultsFutureEffectiveOn(t *testing.T) {
+	now := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	futureDate := "2099-01-01T00:00:00Z"
+	pastDate := "2020-01-01T00:00:00Z"
+
+	source := ecc.Source{
+		Config: &ecc.SourceConfig{
+			Include: []string{"*"},
+		},
+	}
+	configProvider := &simpleConfigProvider{
+		effectiveTime: now,
+	}
+	filter := NewUnifiedPostEvaluationFilter(NewECPolicyResolver(source, configProvider))
+
+	tests := []struct {
+		name            string
+		effectiveTime   time.Time
+		effectiveOn     string
+		severity        string
+		expectWarning   bool
+		expectEnhanced  bool
+		expectedMessage string
+	}{
+		{
+			name:          "severity override demotes failure to warning",
+			effectiveTime: now,
+			effectiveOn:   futureDate,
+			severity:      "warning",
+			expectWarning: true,
+		},
+		{
+			name:            "future effective_on demoted to warning with enhanced message",
+			effectiveTime:   now,
+			effectiveOn:     futureDate,
+			expectWarning:   true,
+			expectEnhanced:  true,
+			expectedMessage: "some failure. This will become a failure starting on " + futureDate,
+		},
+		{
+			name:          "past effective_on stays as failure",
+			effectiveTime: now,
+			effectiveOn:   pastDate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metadata := map[string]interface{}{
+				metadataEffectiveOn: tc.effectiveOn,
+			}
+			if tc.severity != "" {
+				metadata["severity"] = tc.severity
+			}
+
+			result := Result{
+				Message:  "some failure",
+				Metadata: metadata,
+			}
+
+			originalResult := Outcome{
+				Failures: []Result{result},
+			}
+
+			warnings, failures, _, _ := filter.CategorizeResults(
+				[]Result{result}, originalResult, tc.effectiveTime)
+
+			if tc.expectWarning {
+				assert.Len(t, warnings, 1)
+				assert.Empty(t, failures)
+				if tc.expectEnhanced {
+					assert.Equal(t, tc.expectedMessage, warnings[0].Message)
+				}
+			} else {
+				assert.Empty(t, warnings)
+				assert.Len(t, failures, 1)
+			}
+		})
+	}
+}
+
+func TestLegacyCategorizeResultsFutureEffectiveOn(t *testing.T) {
+	now := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+	futureDate := "2099-01-01T00:00:00Z"
+	pastDate := "2020-01-01T00:00:00Z"
+
+	source := ecc.Source{
+		Config: &ecc.SourceConfig{
+			Include: []string{"*"},
+		},
+	}
+	configProvider := &simpleConfigProvider{
+		effectiveTime: now,
+	}
+	filter := NewLegacyPostEvaluationFilter(source, configProvider)
+
+	tests := []struct {
+		name            string
+		effectiveTime   time.Time
+		effectiveOn     string
+		severity        string
+		expectWarning   bool
+		expectEnhanced  bool
+		expectedMessage string
+	}{
+		{
+			name:          "severity override demotes failure to warning",
+			effectiveTime: now,
+			effectiveOn:   futureDate,
+			severity:      "warning",
+			expectWarning: true,
+		},
+		{
+			name:            "future effective_on demoted to warning with enhanced message",
+			effectiveTime:   now,
+			effectiveOn:     futureDate,
+			expectWarning:   true,
+			expectEnhanced:  true,
+			expectedMessage: "some failure. This will become a failure starting on " + futureDate,
+		},
+		{
+			name:          "past effective_on stays as failure",
+			effectiveTime: now,
+			effectiveOn:   pastDate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metadata := map[string]interface{}{
+				metadataCode:        "test.future_rule",
+				metadataEffectiveOn: tc.effectiveOn,
+			}
+			if tc.severity != "" {
+				metadata["severity"] = tc.severity
+			}
+
+			result := Result{
+				Message:  "some failure",
+				Metadata: metadata,
+			}
+
+			originalResult := Outcome{
+				Failures: []Result{result},
+			}
+
+			warnings, failures, _, _ := filter.CategorizeResults(
+				[]Result{result}, originalResult, tc.effectiveTime)
+
+			if tc.expectWarning {
+				assert.Len(t, warnings, 1)
+				assert.Empty(t, failures)
+				if tc.expectEnhanced {
+					assert.Equal(t, tc.expectedMessage, warnings[0].Message)
+				}
+			} else {
+				assert.Empty(t, warnings)
+				assert.Len(t, failures, 1)
+			}
+		})
+	}
+}
+
 func TestUnifiedPostEvaluationFilterVsLegacy(t *testing.T) {
 	// Test that the new comprehensive post-evaluation filter produces
 	// the same results as the legacy filtering approach
@@ -1795,4 +1958,37 @@ func TestPipelineIntentionWithMultipleValues(t *testing.T) {
 		assert.True(t, result.IncludedPackages["security"],
 			"security package should be included (has included rules)")
 	})
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// formatEffectiveOnMessage tests
+//////////////////////////////////////////////////////////////////////////////
+
+func TestFormatEffectiveOnMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		effectiveOn string
+		expected    string
+	}{
+		{
+			name:        "appends enforcement date",
+			message:     "The required 'cpe' label is missing",
+			effectiveOn: "2024-12-01T00:00:00Z",
+			expected:    "The required 'cpe' label is missing. This will become a failure starting on 2024-12-01T00:00:00Z",
+		},
+		{
+			name:        "trims trailing period before appending",
+			message:     "The required 'cpe' label is missing.",
+			effectiveOn: "2025-01-15T00:00:00Z",
+			expected:    "The required 'cpe' label is missing. This will become a failure starting on 2025-01-15T00:00:00Z",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatEffectiveOnMessage(tc.message, tc.effectiveOn)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
 }

--- a/internal/evaluator/filters_test.go
+++ b/internal/evaluator/filters_test.go
@@ -776,7 +776,7 @@ func TestUnifiedCategorizeResultsFutureEffectiveOn(t *testing.T) {
 	tests := []struct {
 		name            string
 		effectiveTime   time.Time
-		effectiveOn     string
+		effectiveOn     interface{}
 		severity        string
 		expectWarning   bool
 		expectEnhanced  bool
@@ -802,12 +802,22 @@ func TestUnifiedCategorizeResultsFutureEffectiveOn(t *testing.T) {
 			effectiveTime: now,
 			effectiveOn:   pastDate,
 		},
+		{
+			name:          "missing effective_on stays as failure without panic",
+			effectiveTime: now,
+		},
+		{
+			name:          "non-string effective_on stays as failure without panic",
+			effectiveTime: now,
+			effectiveOn:   true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			metadata := map[string]interface{}{
-				metadataEffectiveOn: tc.effectiveOn,
+			metadata := map[string]interface{}{}
+			if tc.effectiveOn != nil {
+				metadata[metadataEffectiveOn] = tc.effectiveOn
 			}
 			if tc.severity != "" {
 				metadata["severity"] = tc.severity
@@ -857,7 +867,7 @@ func TestLegacyCategorizeResultsFutureEffectiveOn(t *testing.T) {
 	tests := []struct {
 		name            string
 		effectiveTime   time.Time
-		effectiveOn     string
+		effectiveOn     interface{}
 		severity        string
 		expectWarning   bool
 		expectEnhanced  bool
@@ -883,13 +893,24 @@ func TestLegacyCategorizeResultsFutureEffectiveOn(t *testing.T) {
 			effectiveTime: now,
 			effectiveOn:   pastDate,
 		},
+		{
+			name:          "missing effective_on stays as failure without panic",
+			effectiveTime: now,
+		},
+		{
+			name:          "non-string effective_on stays as failure without panic",
+			effectiveTime: now,
+			effectiveOn:   true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			metadata := map[string]interface{}{
-				metadataCode:        "test.future_rule",
-				metadataEffectiveOn: tc.effectiveOn,
+				metadataCode: "test.future_rule",
+			}
+			if tc.effectiveOn != nil {
+				metadata[metadataEffectiveOn] = tc.effectiveOn
 			}
 			if tc.severity != "" {
 				metadata["severity"] = tc.severity


### PR DESCRIPTION
When the CLI demotes a deny result to a warning due to a future effective_on date, the warning message is now enhanced to indicate when enforcement begins.

Before: "The required 'cpe' label is missing"
After:  "The required 'cpe' label is missing. This will become a failure starting on 2025-01-01T00:00:00Z"

This applies to both sources of effective_on: rule annotations and rule_data items. The effective_on date is included as-is (RFC3339 format), matching the pattern used by trusted_task's future_deny_rule warnings.
No duplicate warnings for trusted_task rules. The enhancement only applies to failures being demoted, not to existing warning rules like `future_deny_rule`.

  ## Test plan
  
  - [ ] Unit tests for `formatFutureEnforcementMessage` covering: valid effective_on, missing metadata, non-string value, empty string, nil metadata
  - [ ] Existing `TestConftestEvaluatorEvaluateSeverity` updated and passing
  - [ ] Full evaluator unit test suite passes with no regressions
  - [ ] Run `ec validate` against a policy with a future `effective_on` date and verify the warning message includes the enforcement date

Ref: https://redhat.atlassian.net/browse/EC-1901
Assisted-by: Claude Opus 4.6