### PR TITLE
fix(EC-1994): correct off-by-one in validate image worker loop

### DIFF
--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -400,7 +400,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			results := make(chan validate_utils.Result, numComponents)
 			// Initialize each worker. They will wait patiently until a job is sent to the jobs
 			// channel, or the jobs channel is closed.
-			for i := 0; i <= numWorkers; i++ {
+			for i := 0; i < numWorkers; i++ {
 				go worker(i, jobs, results)
 			}
 			// Initialize all the jobs. Each worker will pick a job from the channel when the worker

--- a/cmd/validate/image.go
+++ b/cmd/validate/image.go
@@ -401,7 +401,7 @@ func validateImageCmd(validate imageValidationFunc) *cobra.Command {
 			results := make(chan validate_utils.Result, numComponents)
 			// Initialize each worker. They will wait patiently until a job is sent to the jobs
 			// channel, or the jobs channel is closed.
-			for i := 0; i <= numWorkers; i++ {
+			for i := 0; i < numWorkers; i++ {
 				go worker(i, jobs, results)
 			}
 			// Initialize all the jobs. Each worker will pick a job from the channel when the worker

--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -64,7 +64,7 @@ paths can be provided by using the `:` separator.
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 
 +
-*Default*: `4`
+*Default*: `5`
 *EC_USE_OPA* (`string`):: Use the OPA evaluator instead of the default conftest evaluator. Set to "1" to enable.
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +

--- a/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
+++ b/docs/modules/ROOT/pages/verify-conforma-konflux-ta.adoc
@@ -67,7 +67,7 @@ paths can be provided by using the `:` separator.
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 
 +
-*Default*: `4`
+*Default*: `5`
 *EC_USE_OPA* (`string`):: Use the OPA evaluator instead of the default conftest evaluator. Set to "1" to enable.
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +

--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -74,7 +74,7 @@ paths can be provided by using the `:` separator.
 *Default*: `sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2`
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
-*Default*: `1`
+*Default*: `2`
 *EC_USE_OPA* (`string`):: Use the OPA evaluator instead of the default conftest evaluator. Set to "1" to enable.
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +

--- a/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/verify-enterprise-contract.adoc
@@ -77,7 +77,7 @@ paths can be provided by using the `:` separator.
 *Default*: `sha256:f904979d405a39a3cc492439b379b4b117c622bbe7126a0e1ba76527ec3ce6a2`
 *WORKERS* (`string`):: Number of parallel workers to use for policy evaluation.
 +
-*Default*: `1`
+*Default*: `2`
 *EC_USE_OPA* (`string`):: Use the OPA evaluator instead of the default conftest evaluator. Set to "1" to enable.
 *SINGLE_COMPONENT* (`string`):: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
 +

--- a/pipelines/enterprise-contract/0.1/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract/0.1/enterprise-contract.yaml
@@ -66,7 +66,7 @@ spec:
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.
-      default: "1"
+      default: "2"
     - name: CA_TRUST_CONFIGMAP_NAME
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/tasks/verify-conforma-konflux-ta/0.1/README.md
+++ b/tasks/verify-conforma-konflux-ta/0.1/README.md
@@ -31,7 +31,7 @@ kubectl apply -f https://raw.githubusercontent.com/conforma/cli/main/tasks/verif
 * **HOMEDIR**: Value for the HOME environment variable. (default: "/tekton/home")
 * **EFFECTIVE_TIME**: Run policy checks with the provided time. (default: "now")
 * **EXTRA_RULE_DATA**: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..." (default: "")
-* **WORKERS**: Number of parallel workers to use for policy evaluation. This parameter is currently not used. All policy evaluations are run with 35 workers. (default: "35")
+* **WORKERS**: Number of parallel workers to use for policy evaluation. Note: managed release pipelines in `release-service-catalog` override this to 35 via `conforma.workerCount` in `konflux-release-data`. (default: "5")
 * **SINGLE_COMPONENT**: Reduce the Snapshot to only the component whose build caused the Snapshot to be created (default: "false")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE**: Name, including kind, of the Kubernetes resource to query for labels when single component mode is enabled, e.g. pr/somepipeline. (default: "unknown")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE_NS**: Kubernetes namespace where the SINGLE_COMPONENT_NAME is found. Only used when single component mode is enabled. (default: "")

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -177,7 +177,7 @@ spec:
       type: string
       description: >
         Number of parallel workers to use for policy evaluation.
-      default: "4"
+      default: "5"
 
     - name: EC_USE_OPA
       type: string

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -181,7 +181,7 @@ spec:
       type: string
       description: >
         Number of parallel workers to use for policy evaluation.
-      default: "4"
+      default: "5"
 
     - name: EC_USE_OPA
       type: string

--- a/tasks/verify-enterprise-contract/0.1/README.md
+++ b/tasks/verify-enterprise-contract/0.1/README.md
@@ -40,7 +40,7 @@ kubectl apply -f https://raw.githubusercontent.com/conforma/cli/main/tasks/verif
 * **HOMEDIR**: Value for the HOME environment variable. (default: "/tekton/home")
 * **EFFECTIVE_TIME**: Run policy checks with the provided time. (default: "now")
 * **EXTRA_RULE_DATA**: Merge additional Rego variables into the policy data. Use syntax "key=value,key2=value2..." (default: "")
-* **WORKERS**: Number of parallel workers to use for policy evaluation. (default: "1")
+* **WORKERS**: Number of parallel workers to use for policy evaluation. (default: "2")
 * **SINGLE_COMPONENT**: Reduce the Snapshot to only the component whose build caused the Snapshot to be created (default: "false")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE**: Name, including kind, of the Kubernetes resource to query for labels when single component mode is enabled, e.g. pr/somepipeline. (default: "unknown")
 * **SINGLE_COMPONENT_CUSTOM_RESOURCE_NS**: Kubernetes namespace where the SINGLE_COMPONENT_NAME is found. Only used when single component mode is enabled. (default: "")

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -183,7 +183,7 @@ spec:
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.
-      default: "1"
+      default: "2"
 
     - name: EC_USE_OPA
       type: string

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -187,7 +187,7 @@ spec:
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.
-      default: "1"
+      default: "2"
 
     - name: EC_USE_OPA
       type: string


### PR DESCRIPTION
## Summary
- Fix off-by-one in worker loop at `cmd/validate/image.go:404`: `<=` changed to `<` so the loop spawns exactly `numWorkers` goroutines instead of `numWorkers+1`
- Bump task worker defaults by 1 to preserve the effective concurrency users had before the fix (since the old `<=` loop spawned N+1 workers for a configured value of N):
  - `verify-conforma-konflux-ta`: 4 → 5
  - `verify-enterprise-contract`: 1 → 2
- Update READMEs and generated docs to match new defaults; fix stale documentation that incorrectly claimed WORKERS was unused and defaulted to 35

## Test plan
- [x] `go build ./cmd/validate/` passes
- [x] `go test -tags=unit ./cmd/validate/ -run TestValidateImage` passes
- [x] `make generate` produces no additional diff

Resolves: https://redhat.atlassian.net/browse/EC-1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)