### PR TITLE
Pin third-party action to immutable ref in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,15 +65,14 @@ jobs:
       TAG_TIMESTAMP: ${{ github.sha }}-${{ needs.info.outputs.timestamp }}
 
     steps:
-      # TODO: Enabling this seems to cause the host to run out of disk space.
-      # - name: Harden Runner
-      #   uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-      #   with:
-      #     egress-policy: audit
-      #     disable-telemetry: true
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+          disable-telemetry: true
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           docker-images: false
           swap-storage: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>conforma/.github//config/renovate/renovate.json"
+    "github>conforma/.github//config/renovate/renovate.json",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
## Summary

- **Pinned `jlumbroso/free-disk-space`** from mutable `@main` to immutable SHA `@54081f138730dfa15788a46383842cd2f914a1be` (v1.3.1). This action runs in a job with `contents: write`, `pages: write`, and `id-token: write` permissions — a compromised upstream pushing to `main` could sign and publish arbitrary releases. CVSS 8.0.

- **Re-enabled `step-security/harden-runner`** at v2.20.1 (was commented out at v2.4.1). The original concern was disk space exhaustion, but `free-disk-space` now reclaims ~30GB before subsequent steps run. In `egress-policy: audit` mode, harden-runner monitors network egress without blocking — low risk, high visibility into what the release job contacts.

- **Added `helpers:pinGitHubActionDigests`** to `renovate.json`. This Renovate preset does two things: (1) automatically opens PRs to pin any future actions added with a mutable tag ref (e.g. `@v3`) to their full SHA digest, and (2) keeps existing SHA-pinned actions up to date when new versions are released. This is scoped to `cli` only — it extends the shared org config without modifying it, so it can be promoted to `conforma/.github` later if the team wants org-wide coverage.

## Test plan

- [ ] Verify release workflow runs successfully (harden-runner + free-disk-space don't exhaust disk)
- [ ] Confirm Renovate picks up the new preset and doesn't produce config errors
- [ ] Check harden-runner audit output appears in the workflow logs

Resolves: EC-2045

🤖 Generated with [Claude Code](https://claude.com/claude-code)