### PR TITLE
Fix case-insensitive HTTP scheme bypass in isSecure()

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -151,5 +151,6 @@ var insecure = regexp.MustCompile("^[A-Za-z0-9]*::http:")
 //   - http  -- not deemed secure
 //   - https -- deemed secure
 func isSecure(url string) bool {
-	return !strings.HasPrefix(url, "http:") && !insecure.MatchString(url)
+	lower := strings.ToLower(url)
+	return !strings.HasPrefix(lower, "http:") && !insecure.MatchString(lower)
 }

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -142,7 +142,11 @@ func TestIsSecure(t *testing.T) {
 
 	insecure := []string{
 		"http://example.com",
+		"Http://example.com",
+		"HTTP://example.com",
+		"hTTp://example.com",
 		"git::http://github.com/org/repository",
+		"git::Http://github.com/org/repository",
 		"hg::http://github.com/org/repository",
 		"http::http://github.com/org/repository",
 		"s3::http://127.0.0.1:9000/test-bucket/hello.txt?aws_access_key_id=KEYID&aws_access_key_secret=SECRETKEY&region=us-east-2",


### PR DESCRIPTION
Lowercase the URL before checking for insecure HTTP schemes, preventing mixed-case variants like Http:// or HTTP:// from bypassing the transport security check.

Ref: https://issues.redhat.com/browse/EC-2014