### PR TITLE
chore(deps): Update ubi-minimal base image (v0.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Update ubi-minimal base image to latest digest.

Old digest: `sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f`
New digest: `sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1`

### RPM changes

```diff
- gnutls-3.8.10-4.el9_8.x86_64
+ gnutls-3.8.10-8.el9_8.x86_64
- libgcrypt-1.10.0-11.el9.x86_64
+ libgcrypt-1.10.0-13.el9_8.x86_64
```

Ref: https://redhat.atlassian.net/browse/EC-2076