### PR TITLE
[DNM] Add roxctl-scan task to pull request pipeline

### DIFF
--- a/.tekton/cli-main-pull-request.yaml
+++ b/.tekton/cli-main-pull-request.yaml
@@ -579,6 +579,28 @@ spec:
         operator: in
         values:
         - "false"
+    - name: roxctl-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: roxctl-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:63614a21526f2b3e00d2e795be797b4db6fe124184a58e9c8b2e507addebe9fb
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/cli-main-pull-request.yaml
+++ b/.tekton/cli-main-pull-request.yaml
@@ -589,13 +589,13 @@ spec:
       - build-image-index
       taskRef:
         params:
-        - name: name
-          value: roxctl-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:63614a21526f2b3e00d2e795be797b4db6fe124184a58e9c8b2e507addebe9fb
-        - name: kind
-          value: task
-        resolver: bundles
+        - name: url
+          value: https://github.com/cuipinghuo/konflux-test-tasks
+        - name: revision
+          value: stoneintg-1755-fix-roxctl-oci-attach
+        - name: pathInRepo
+          value: task/roxctl-scan/0.1/roxctl-scan.yaml
+        resolver: git
       when:
       - input: $(params.skip-checks)
         operator: in


### PR DESCRIPTION
## Summary
- Add the `roxctl-scan` task to the `cli-main-pull-request.yaml` Tekton pipeline
- The task runs after `build-image-index` and scans the built image using RHACS/Stackrox
- Resolved via Tekton bundle at `quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1` with pinned digest
- Skipped when `skip-checks` is `"true"`, consistent with other scan tasks

This is to experiment with the roxctl-scan report, hence the DNM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)