### PR TITLE
Add imagePullPolicy: IfNotPresent to task and pipeline steps

### DIFF
--- a/release/cli.yaml
+++ b/release/cli.yaml
@@ -92,6 +92,7 @@ spec:
         - $(results.cli-snapshot-spec.path)
         - $(results.bundle-snapshot-spec.path)
         image: quay.io/konflux-ci/task-runner:v1
+        imagePullPolicy: IfNotPresent
         name: expand
         workingDir: $(workspaces.source.path)/source
       workspaces:
@@ -182,12 +183,14 @@ spec:
         - $(params.cli-snapshot-spec)
         - $(params.cli-target-repo)
         image: quay.io/konflux-ci/task-runner:v1
+        imagePullPolicy: IfNotPresent
         name: copy-cli
       - command:
         - hack/copy-snapshot-image.sh
         - $(params.bundle-snapshot-spec)
         - $(params.bundle-target-repo)
         image: quay.io/konflux-ci/task-runner:v1
+        imagePullPolicy: IfNotPresent
         name: copy-bundle
       # To ease the transtion from the old quay org to the new quay org,
       # also push the two images to the old quay org at. Rather than
@@ -201,6 +204,7 @@ spec:
         # Hard-coded "old" $(params.cli-target-repo):
         - quay.io/enterprise-contract/cli
         image: quay.io/konflux-ci/task-runner:v1
+        imagePullPolicy: IfNotPresent
         name: copy-cli-old-org
       - command:
         - hack/copy-snapshot-image.sh
@@ -208,6 +212,7 @@ spec:
         # Hard-coded "old" $(params.bundle-target-repo)
         - quay.io/enterprise-contract/tekton-task
         image: quay.io/konflux-ci/task-runner:v1
+        imagePullPolicy: IfNotPresent
         name: copy-bundle-old-org
       workspaces:
       - name: source

--- a/tasks/collect-keyless-params/0.1/collect-keyless-params.yaml
+++ b/tasks/collect-keyless-params/0.1/collect-keyless-params.yaml
@@ -89,6 +89,7 @@ spec:
   steps:
     - name: collect-signing-params
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
 
       computeResources:
         limits:

--- a/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
+++ b/tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml
@@ -320,6 +320,7 @@ spec:
 
     - name: initialize-tuf
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       script: |-
         set -euo pipefail
 
@@ -348,6 +349,7 @@ spec:
         - name: SNAPSHOT_PATH
           value: $(params.HOMEDIR)/snapshot.json
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [reduce-snapshot.sh]
 
@@ -358,11 +360,13 @@ spec:
         - name: POLICY_BUNDLE_DIGEST
           value: $(params.POLICY_BUNDLE_DIGEST)
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue
       command: [pin-konflux-policy-bundle.sh]
 
     - name: validate
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue # progress even if the step fails so we can see the debug logs
       script: |
         #!/bin/bash
@@ -563,6 +567,7 @@ spec:
 
     - name: report-json
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [sh, -c]
       args:
@@ -576,6 +581,7 @@ spec:
 
     - name: summary
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [jq]
       args:
@@ -584,12 +590,14 @@ spec:
 
     - name: version
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [ec]
       args:
         - version
 
     - name: show-config
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [jq]
       args:
         - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
@@ -597,6 +605,7 @@ spec:
 
     - name: detailed-report
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue
       command: ["cat"]
       args:
@@ -604,6 +613,7 @@ spec:
 
     - name: assert
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [jq]
       args:
         - "--argjson"

--- a/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -262,6 +262,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [ec]
       args:
         - sigstore
@@ -294,6 +295,7 @@ spec:
         - name: SNAPSHOT_PATH
           value: $(params.HOMEDIR)/snapshot.json
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue # progress even if the step fails so we can see the debug logs
       command: [reduce-snapshot.sh]
 
@@ -310,11 +312,13 @@ spec:
         - name: POLICY_BUNDLE_DIGEST
           value: $(params.POLICY_BUNDLE_DIGEST)
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue
       command: [pin-konflux-policy-bundle.sh]
 
     - name: validate
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue # progress even if the step fails so we can see the debug logs
       script: |
         #!/bin/bash
@@ -468,6 +472,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [sh, -c]
       args:
@@ -487,6 +492,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue  # progress even if the step fails so we can see the debug logs
       command: [jq]
       args:
@@ -501,6 +507,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [ec]
       args:
         - version
@@ -513,6 +520,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [jq]
       args:
         - '{policy: .policy, key: .key, "effective-time": .["effective-time"]}'
@@ -520,6 +528,7 @@ spec:
 
     - name: detailed-report
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       onError: continue
       command: ["cat"]
       args:
@@ -533,6 +542,7 @@ spec:
         limits:
           memory: 256Mi
       image: quay.io/conforma/cli:latest
+      imagePullPolicy: IfNotPresent
       command: [jq]
       args:
         - "--argjson"


### PR DESCRIPTION
## Summary

Add `imagePullPolicy: IfNotPresent` to all task and pipeline steps using floating tags to avoid unnecessary image pulls on every run.

- **release/cli.yaml** — 5 steps using `quay.io/konflux-ci/task-runner:v1`
- **verify-enterprise-contract task** — 10 steps using `quay.io/conforma/cli:latest`
- **verify-conforma-konflux-ta task** — 10 steps using `quay.io/conforma/cli:latest`
- **collect-keyless-params task** — 1 step using `quay.io/conforma/cli:latest`

Note: The `conforma/cli:latest` refs are placeholders replaced at bundle-build time by `yq` with commit-specific tags (`gh-<sha>`). Setting `IfNotPresent` is safe because the actual published bundles use unique-per-commit tags.

## Test plan

- [ ] CI passes
- [ ] Release pipeline runs successfully with `IfNotPresent`

Resolves: EC-2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)