### PR TITLE
fix: add --allow-past-effective-time to simple benchmark

### DIFF
--- a/benchmark/simple/simple.go
+++ b/benchmark/simple/simple.go
@@ -107,6 +107,7 @@ func ec(dir string) func() {
 			"--ignore-rekor",
 			"--effective-time",
 			"2024-12-10T00:00:00Z",
+			"--allow-past-effective-time",
 		}); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
The simple benchmark uses --effective-time with a past date (2024-12-10) but does not pass --allow-past-effective-time, which is now required since past effective times are rejected by default.

#### What:
<!--- What is this change doing? --->

 Add `--allow-past-effective-time` flag to the simple benchmark's argument list.

#### Why:
<!--- Please include the context and background for your change. --->

The simple benchmark uses `--effective-time` 2024-12-10T00:00:00Z (a past date) but past effective times are now rejected by default (PR #3424). Without this flag the benchmark fails at runtime with: "effective time … is in the past; use --allow-past-effective-time to override".

The stress benchmark already has this flag (added in EC-1818). This brings the simple benchmark in line.

#### Tickets:
<!--- Please link to any related Jira issue here. --->

N/A — pre-existing issue surfaced during EC-1819 review.
