### PR TITLE
chore(deps): Update ubi-minimal base image (v0.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/hack/update-rpm-lock.sh
+++ b/hack/update-rpm-lock.sh
@@ -75,10 +75,11 @@ base_image_repos=$(mktemp -d --tmpdir)
 # extract all /etc/yum.repos.d/* files from the base image
 oc image extract "${base_img}" --path /etc/yum.repos.d/*.repo:"${base_image_repos}"
 
-# enable source repositories
-for r in $(dnf repolist --setopt=reposdir="${base_image_repos}" --disabled --quiet|grep -- -source | sed "s/ .*//"); do
-    dnf config-manager --quiet --setopt=reposdir="${base_image_repos}" "${r}" --set-enabled
-done
+# In the past we used to add enable the source repos, but now we follow the example
+# set by MintMaker's automated lock file update PRs and leave the source repos disabled
+#for r in $(dnf repolist --setopt=reposdir="${base_image_repos}" --disabled --quiet|grep -- -source | sed "s/ .*//"); do
+#    dnf config-manager --quiet --setopt=reposdir="${base_image_repos}" "${r}" --set-enabled
+#done
 
 # convert ubi repo ids to archful format for better sbom data
 sed -i 's/^\[ubi-9-/\[ubi-9-for-$basearch-/' "${base_image_repos}"/*.repo


### PR DESCRIPTION
Update ubi-minimal base image to latest digest.

Old digest: `sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221`
New digest: `sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41`

### RPM changes

```diff
- curl-minimal-7.76.1-40.el9.x86_64
+ curl-minimal-7.76.1-40.el9_8.5.x86_64
- glib2-2.68.4-19.el9_8.2.x86_64
+ glib2-2.68.4-19.el9_8.9.x86_64
- libcurl-minimal-7.76.1-40.el9.x86_64
+ libcurl-minimal-7.76.1-40.el9_8.5.x86_64
- libnghttp2-1.43.0-6.el9_8.1.x86_64
+ libnghttp2-1.43.0-6.el9_8.2.x86_64
```

Also cherry-pick one commit from main branch so we don't add keep adding source rpms to rpm.lock.yaml when running `hack/update-rpm-lock.sh`. This will help make these automated UBI bump PRs more smooth and consistent.


Ref: https://redhat.atlassian.net/browse/EC-2115
Ref: https://redhat.atlassian.net/browse/EC-2114