### PR TITLE
chore(deps): Update ubi-minimal base image (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -43,7 +43,7 @@ RUN /build/build.sh "${BUILD_LIST}" "${BUILD_SUFFIX}"
 
 ## Final image
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/acceptance/kubernetes/kind/acceptance.Dockerfile
+++ b/acceptance/kubernetes/kind/acceptance.Dockerfile
@@ -17,7 +17,7 @@
 # Minimal image for acceptance tests. The ec and kubectl binaries are
 # pre-built on the host and injected here to avoid the multi-stage Go
 # compilation that the production Dockerfile uses.
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41
 
 RUN microdnf upgrade --assumeyes --nodocs --setopt=keepcache=0 --refresh && microdnf -y --nodocs --setopt=keepcache=0 install gzip jq ca-certificates
 


### PR DESCRIPTION
Update ubi-minimal base image to latest digest.

Old digest: `sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221`
New digest: `sha256:8eb2830d0936237fc13a1f2f7e45aecf90d69043380ad167fad0343632937f41`

### RPM changes

```diff
- curl-minimal-7.76.1-40.el9.x86_64
+ curl-minimal-7.76.1-40.el9_8.5.x86_64
- glib2-2.68.4-19.el9_8.2.x86_64
+ glib2-2.68.4-19.el9_8.9.x86_64
- libcurl-minimal-7.76.1-40.el9.x86_64
+ libcurl-minimal-7.76.1-40.el9_8.5.x86_64
- libnghttp2-1.43.0-6.el9_8.1.x86_64
+ libnghttp2-1.43.0-6.el9_8.2.x86_64
```

Ref: https://redhat.atlassian.net/browse/EC-2115
Ref: https://redhat.atlassian.net/browse/EC-2114