### PR TITLE
Restore commented out acceptance test scenario

### DIFF
--- a/features/validate_image.feature
+++ b/features/validate_image.feature
@@ -1461,26 +1461,25 @@ Feature: evaluate enterprise contract
     Then the exit status should be 0
     Then the output should match the snapshot
 
-  # Commented out as part of EC-1023. This will be enabled once the issue is resolved.
-  # Scenario: many components and sources
-  #   Given a key pair named "known"
-  #     And a git repository named "multitude-policy" with
-  #     | main.rego | examples/happy_day.rego |
-  #     And policy configuration named "ec-policy" with 10 policy sources from "git::https://${GITHOST}/git/multitude-policy.git", patched with
-  #     | [{"op": "add", "path": "/sources/0/ruleData", "value": {"key": "value"}}]      |
-  #     | [{"op": "add", "path": "/sources/1/ruleData", "value": {"something": "here"}}] |
-  #     | [{"op": "add", "path": "/sources/2/ruleData", "value": {"key": "different"}}]  |
-  #     | [{"op": "add", "path": "/sources/3/ruleData", "value": {"hello": "world"}}]    |
-  #     | [{"op": "add", "path": "/sources/4/ruleData", "value": {"foo": "bar"}}]        |
-  #     | [{"op": "add", "path": "/sources/5/ruleData", "value": {"peek": "poke"}}]      |
-  #     | [{"op": "add", "path": "/sources/6/ruleData", "value": {"hide": "seek"}}]      |
-  #     | [{"op": "add", "path": "/sources/7/ruleData", "value": {"hokus": "pokus"}}]    |
-  #     | [{"op": "add", "path": "/sources/8/ruleData", "value": {"mr": "mxyzptlk"}}]    |
-  #     | [{"op": "add", "path": "/sources/9/ruleData", "value": {"more": "data"}}]      |
-  #     And an Snapshot named "multitude" with 10 components signed with "known" key
-  #   When ec command is run with "validate image --snapshot acceptance/multitude --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json"
-  #   Then the exit status should be 0
-  #    And the output should match the snapshot
+  Scenario: many components and sources
+    Given a key pair named "known"
+      And a git repository named "multitude-policy" with
+      | main.rego | examples/happy_day.rego |
+      And policy configuration named "ec-policy" with 10 policy sources from "git::https://${GITHOST}/git/multitude-policy.git", patched with
+      | [{"op": "add", "path": "/sources/0/ruleData", "value": {"key": "value"}}]      |
+      | [{"op": "add", "path": "/sources/1/ruleData", "value": {"something": "here"}}] |
+      | [{"op": "add", "path": "/sources/2/ruleData", "value": {"key": "different"}}]  |
+      | [{"op": "add", "path": "/sources/3/ruleData", "value": {"hello": "world"}}]    |
+      | [{"op": "add", "path": "/sources/4/ruleData", "value": {"foo": "bar"}}]        |
+      | [{"op": "add", "path": "/sources/5/ruleData", "value": {"peek": "poke"}}]      |
+      | [{"op": "add", "path": "/sources/6/ruleData", "value": {"hide": "seek"}}]      |
+      | [{"op": "add", "path": "/sources/7/ruleData", "value": {"hokus": "pokus"}}]    |
+      | [{"op": "add", "path": "/sources/8/ruleData", "value": {"mr": "mxyzptlk"}}]    |
+      | [{"op": "add", "path": "/sources/9/ruleData", "value": {"more": "data"}}]      |
+      And an Snapshot named "multitude" with 10 components signed with "known" key
+    When ec command is run with "validate image --snapshot acceptance/multitude --policy acceptance/ec-policy --public-key ${known_PUBLIC_KEY} --rekor-url ${REKOR} --show-successes --output json"
+    Then the exit status should be 0
+     And the output should match the snapshot
 
   Scenario: Format options
     Given a key pair named "known"


### PR DESCRIPTION
I believe it was failing at some point, so it was commented out. https://redhat.atlassian.net/browse/EC-1023 is meant to describe the reason for the failure.

It's not clear to me what the detailed story is, but this comment and the revert PR it is part of are definitely clues: https://github.com/conforma/cli/pull/2176#issuecomment-2486792741

Seems to work fine now, so let's bring it back. See also https://github.com/conforma/cli/commit/44618120b295398353f99b565c8c2ef24a9231eb to help understand the purpose of the test.