### PR TITLE
Remove local helpers:pinGitHubActionDigests override

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>conforma/.github//config/renovate/renovate.json",
-    "helpers:pinGitHubActionDigests"
+    "github>conforma/.github//config/renovate/renovate.json"
   ]
 }


### PR DESCRIPTION
## Summary

- Removes the local `helpers:pinGitHubActionDigests` override from `renovate.json`
- This preset is now provided by the org-wide Renovate config at `conforma/.github` (see [conforma/.github#85](https://github.com/conforma/.github/pull/85))

## Note

This PR should be merged **after** [conforma/.github#85](https://github.com/conforma/.github/pull/85) to ensure continuity of the pinning behavior.

Resolves: [EC-2080](https://redhat.atlassian.net/browse/EC-2080)