### PR TITLE
Find roxctl reports also using benchmark offliner

### DIFF
--- a/benchmark/offliner/scans.go
+++ b/benchmark/offliner/scans.go
@@ -87,7 +87,7 @@ func scanReports(ref name.Reference) ([]name.Reference, error) {
 		for _, task := range tasks {
 			task := task.(map[string]any)
 			// TODO match by reference instead of name
-			if task["name"] != "clair-scan" {
+			if task["name"] != "clair-scan" && task["name"] != "roxctl-scan" {
 				continue
 			}
 


### PR DESCRIPTION
We're moving from clair-scan to roxctl-scan. This change should ensure that the benchmark offliner utility finds the roxctl-scan reports the same way it finds the clair-scan reports.
