### PR TITLE
Set cpe label for v0.9 release build

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -49,7 +49,8 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL \
-  name="ec" \
+  name="rhtas/ec-rhel9" \
+  cpe="cpe:/a:redhat:trusted_artifact_signer:1.5::el9" \
   description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   io.k8s.description="Conforma verifies and checks supply chain artifacts to ensure they meet security and business policies." \
   summary="Provides the binaries for downloading the Conforma CLI. Also used as a runner image for Tekton tasks." \


### PR DESCRIPTION
The Red Hat builds of Conforma need a proper CPE, otherwise the 'check-labels' task in the release pipeline fails. Also change the "name" label to be consistent with previous releases, since the release pipeline requires this exact name.

Ref: https://redhat.atlassian.net/browse/EC-2154