### PR TITLE
Automate CPE label update in release branch setup script

### DIFF
--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -104,6 +104,11 @@ if [[ -z "$CPE_VERSION" ]]; then
   exit 1
 fi
 
+if [[ ! "$CPE_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: CPE version must be in MAJOR.MINOR format (e.g. 1.5), got: ${CPE_VERSION}"
+  exit 1
+fi
+
 sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${CPE_VERSION}::el9\"|" Dockerfile.dist
 
 echo "Updated Dockerfile.dist labels:"

--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -91,6 +91,26 @@ EOT
 awk "$awk_query" <(git show main:$MAIN_PR_PIPELINE) > $RELEASE_PR_PIPELINE
 awk "$awk_query" <(git show main:$MAIN_PUSH_PIPELINE) > $RELEASE_PUSH_PIPELINE
 
+# Set the CPE and name labels in Dockerfile.dist for the release branch.
+# The CPE version is a Red Hat product version that doesn't necessarily follow
+# the Conforma version, so it must be provided explicitly.
+CPE_VERSION="${CPE_VERSION:-}"
+if [[ -z "$CPE_VERSION" ]]; then
+  read -rp "Enter the CPE version for this release (e.g. 1.5): " CPE_VERSION
+fi
+
+if [[ -z "$CPE_VERSION" ]]; then
+  echo "Error: CPE version is required"
+  exit 1
+fi
+
+sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${CPE_VERSION}::el9\"|" Dockerfile.dist
+
+echo "Updated Dockerfile.dist labels:"
+echo "  name=\"rhtas/ec-rhel9\""
+echo "  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${CPE_VERSION}::el9\""
+echo ""
+
 echo "To review the new pipeline definitions:"
 echo "  vimdiff <(git show main:$MAIN_PR_PIPELINE) $RELEASE_PR_PIPELINE"
 echo "  vimdiff <(git show main:$MAIN_PUSH_PIPELINE) $RELEASE_PUSH_PIPELINE"
@@ -100,4 +120,4 @@ echo "  vimdiff <(git show release-v$OLD_VERSION:$OLD_RELEASE_PUSH_PIPELINE) $RE
 echo ""
 echo "If the above comparisons look good then you probably want to do this:"
 echo "  git rm $MAIN_PR_PIPELINE $MAIN_PUSH_PIPELINE"
-echo "  git add $RELEASE_PR_PIPELINE $RELEASE_PUSH_PIPELINE"
+echo "  git add $RELEASE_PR_PIPELINE $RELEASE_PUSH_PIPELINE Dockerfile.dist"

--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -109,7 +109,8 @@ if [[ ! "$TAS_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\"|" Dockerfile.dist
+sed -i.bak -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\"|" Dockerfile.dist
+rm -f Dockerfile.dist.bak
 
 grep -q "cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9" Dockerfile.dist || {
   echo "Error: failed to update Dockerfile.dist labels (pattern not found — file may already be patched, or the label format changed)"
@@ -117,7 +118,7 @@ grep -q "cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9" Dockerfile.d
 }
 
 echo "Updated Dockerfile.dist labels:"
-echo "  name=\"rhtas/ec-rhel9\""
+echo "  name=\"rhtas/ec-rhel9\" \\"
 echo "  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\""
 echo ""
 

--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -111,6 +111,11 @@ fi
 
 sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\"|" Dockerfile.dist
 
+grep -q "cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9" Dockerfile.dist || {
+  echo "Error: failed to update Dockerfile.dist labels (pattern not found — file may already be patched, or the label format changed)"
+  exit 1
+}
+
 echo "Updated Dockerfile.dist labels:"
 echo "  name=\"rhtas/ec-rhel9\""
 echo "  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\""

--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -92,28 +92,28 @@ awk "$awk_query" <(git show main:$MAIN_PR_PIPELINE) > $RELEASE_PR_PIPELINE
 awk "$awk_query" <(git show main:$MAIN_PUSH_PIPELINE) > $RELEASE_PUSH_PIPELINE
 
 # Set the CPE and name labels in Dockerfile.dist for the release branch.
-# The CPE version is a Red Hat product version that doesn't necessarily follow
+# The TAS (Trusted Artifact Signer) version doesn't necessarily follow
 # the Conforma version, so it must be provided explicitly.
-CPE_VERSION="${CPE_VERSION:-}"
-if [[ -z "$CPE_VERSION" ]]; then
-  read -rp "Enter the CPE version for this release (e.g. 1.5): " CPE_VERSION
+TAS_VERSION="${TAS_VERSION:-}"
+if [[ -z "$TAS_VERSION" ]]; then
+  read -rp "Enter the TAS version for this release (e.g. 1.5): " TAS_VERSION
 fi
 
-if [[ -z "$CPE_VERSION" ]]; then
-  echo "Error: CPE version is required"
+if [[ -z "$TAS_VERSION" ]]; then
+  echo "Error: TAS version is required"
   exit 1
 fi
 
-if [[ ! "$CPE_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-  echo "Error: CPE version must be in MAJOR.MINOR format (e.g. 1.5), got: ${CPE_VERSION}"
+if [[ ! "$TAS_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: TAS version must be in MAJOR.MINOR format (e.g. 1.5), got: ${TAS_VERSION}"
   exit 1
 fi
 
-sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${CPE_VERSION}::el9\"|" Dockerfile.dist
+sed -i'' -e "s|name=\"ec\"|name=\"rhtas/ec-rhel9\" \\\\\\n  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\"|" Dockerfile.dist
 
 echo "Updated Dockerfile.dist labels:"
 echo "  name=\"rhtas/ec-rhel9\""
-echo "  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${CPE_VERSION}::el9\""
+echo "  cpe=\"cpe:/a:redhat:trusted_artifact_signer:${TAS_VERSION}::el9\""
 echo ""
 
 echo "To review the new pipeline definitions:"


### PR DESCRIPTION
#### What:
<!--- What is this change doing? --->

The release-branch-pipeline-patch.sh script now also updates the name and cpe labels in Dockerfile.dist, which were previously done as a separate manual PR for each release branch. The CPE version is accepted via the CPE_VERSION env var or an interactive prompt.

#### Why:
<!--- Please include the context and background for your change. --->

I'm lazy

#### Tickets:
<!--- Please link to any related Jira issue here. --->

Ref: https://redhat.atlassian.net/browse/EC-2154