### PR TITLE
fix: Remove reference to deleted quick-build-args.conf

### DIFF
--- a/hack/release-branch-pipeline-patch.sh
+++ b/hack/release-branch-pipeline-patch.sh
@@ -61,7 +61,7 @@ awk_query=$(cat <<EOT
   gsub(/== "main"/, "== \"release-v$VERSION\"");
 
   # We use different build args in the release branch
-  gsub(/main-pre-merge-build-args.conf/, "quick-build-args.conf");
+  gsub(/main-pre-merge-build-args.conf/, "\"\"");
   gsub(/main-build-args.conf/, "\"\"");
 
   # Replace "main" in several places


### PR DESCRIPTION
#### What:
<!--- What is this change doing? --->
Since PR #2478 removed the build args files, the release branch script should set both build args to empty string instead of referencing the no longer existing quick-build-args.conf.

#### Why:
<!--- Please include the context and background for your change. --->

So, we won't have to manually remove it anymore.

#### Tickets:
<!--- Please link to any related Jira issue here. --->

Ref: https://redhat.atlassian.net/browse/EC-2154