### PR TITLE
docs(EC-2061): document dependency management strategy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,7 @@ System-level issues that surface in acceptance tests:
 | Podman container failures | Use user service: `systemctl enable --user --now podman.socket` |
 | Too many containers (inotify) | `echo fs.inotify.max_user_watches=524288 \| sudo tee -a /etc/sysctl.conf` |
 | Key limit errors | `echo kernel.keys.maxkeys=1000 \| sudo tee -a /etc/sysctl.conf` |
+
+## Dependency Management
+
+Go version updates are managed by both Renovate and Mintmaker (`red-hat-konflux[bot]`). The local `renovate.json` extends the org-level preset at `conforma/.github` with an additional `helpers:pinGitHubActionDigests` extension. The org-level config's dependency grouping strategy for Go has changed over time — config comments may reference a "go version" group that was never fully implemented. Do not propose changes to the Renovate or Mintmaker configuration for Go version management (e.g., adding package rules, re-enabling or disabling automated Go version bumps, or creating new dependency groups) without explicit maintainer approval.


### PR DESCRIPTION
#### What:
Add a "Dependency Management" section to AGENTS.md documenting that Go version updates are managed by both Renovate and Mintmaker, and that agents should not propose changes to this configuration without maintainer approval.

#### Why:
An AI agent pipeline (retro → triage → code → review) filed a PR proposing to add a missing "go version" group to Renovate config. The PR was closed without merge because the absence was intentional. Without documentation in AGENTS.md, agents cannot distinguish between "missing config" and "deliberately omitted config." This section provides that context to prevent future false-positive proposals.

#### Tickets:
- [EC-2061](https://redhat.atlassian.net/browse/EC-2061)
- Upstream: https://github.com/conforma/cli/issues/3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)