### PR TITLE
chore(deps): advance .fullsend dispatch pin to pinned main

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -57,7 +57,7 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: conforma/.fullsend/.github/workflows/dispatch.yml@87c4a29e530c4231be1ff214f81765f03cc178ff # main
+    uses: conforma/.fullsend/.github/workflows/dispatch.yml@cd011389fdff80dc8ef963f82f7f200901e62f5c # main
     with:
       event_action: ${{ github.event.action }}
 


### PR DESCRIPTION
Advances the `conforma/.fullsend` dispatch pin `87c4a29e → cd011389` (current, fully SHA-pinned main). Fixes `startup_failure` on the `fullsend` workflow under org-wide `sha_pinning_required` — the old pinned SHA's agent workflows still used unpinned `actions/checkout@v6` / `fullsend-ai/...@v0`.

Ref: EC-2173